### PR TITLE
PIP-13: Meta-Transaction Fee Auto-Swap to PCE

### DIFF
--- a/PIPs/pip-13.md
+++ b/PIPs/pip-13.md
@@ -1,5 +1,5 @@
 ---
-pip: 3
+pip: 13
 title: Meta-Transaction Fee Auto-Swap to PCE
 proposer: chiba (on GitHub)
 status: Draft
@@ -9,7 +9,7 @@ requires: []
 replaces: []
 ---
 
-## PIP-3: Meta-Transaction Fee Auto-Swap to PCE
+## PIP-13: Meta-Transaction Fee Auto-Swap to PCE
 
 ### Abstract
 
@@ -204,6 +204,6 @@ All examples use `INITIAL_FACTOR = 10^18`.
 ### Notes
 
 - **Scope of impact**: Requires upgrades to both PCEToken and PCECommunityToken contracts
-- **Interaction with PIP-2**: If PIP-2 (Community Treasury Wallet) is implemented, fee swaps reduce the PCEToken contract's PCE balance but do not modify `depositedPCEToken` for the community. This is consistent with how regular `swapFromLocalToken` operates — `depositedPCEToken` tracks capital operations only, not swap activity.
+- **Interaction with PIP-12**: If PIP-12 (Community Treasury Wallet) is implemented, fee swaps reduce the PCEToken contract's PCE balance but do not modify `depositedPCEToken` for the community. This is consistent with how regular `swapFromLocalToken` operates — `depositedPCEToken` tracks capital operations only, not swap activity.
 - **Out of scope**: Relayer fee margin configuration (e.g., markup for profit) is not addressed. Native token conversion (PCE → MATIC/POL) for actual gas payment remains the relayer's responsibility.
 - **Dependencies**: None (builds on existing meta-transaction and swap infrastructure)

--- a/PIPs/pip-3.md
+++ b/PIPs/pip-3.md
@@ -1,0 +1,209 @@
+---
+pip: 3
+title: Meta-Transaction Fee Auto-Swap to PCE
+proposer: chiba (on GitHub)
+status: Draft
+type: Core
+created: 2026-03-13
+requires: []
+replaces: []
+---
+
+## PIP-3: Meta-Transaction Fee Auto-Swap to PCE
+
+### Abstract
+
+This proposal changes meta-transaction fee settlement from direct community token transfer to automatic PCE conversion. When a relayer executes a meta-transaction, the fee collected from the user in community tokens is burned and the equivalent amount of PCE is transferred to the relayer. This swap is exempt from daily swap limits.
+
+### Motivation
+
+In the current design, meta-transaction fees are collected in the community token being transacted and transferred directly to the relayer (`_msgSender()`). This creates two problems:
+
+1. **Relayer token fragmentation**: Relayers accumulate many types of community tokens across communities. These tokens have limited immediate utility — relayers need PCE (or native tokens) to cover gas costs, not a portfolio of community tokens.
+
+2. **Manual swap burden with rate limits**: To convert accumulated community tokens to PCE, relayers must call `swapFromLocalToken` for each token type, subject to daily global and individual swap limits. During high-activity periods, relayers may be unable to swap their earned fees due to exhausted limits.
+
+This proposal solves both problems by automatically converting fees to PCE at the point of collection, exempt from swap limits.
+
+### Specification
+
+#### Interface
+
+**PCEToken — new function:**
+
+```solidity
+/// @notice Swaps community token fee to PCE and transfers to relayer.
+///         Only callable by the community token contract itself.
+///         Exempt from daily swap limits.
+/// @param fromToken The community token contract address (must equal msg.sender)
+/// @param relayer The relayer address to receive PCE
+/// @param communityTokenDisplayAmount The fee amount in community token display units
+/// @return pceAmount The amount of PCE transferred to the relayer
+function swapFeeFromLocalToken(
+    address fromToken,
+    address relayer,
+    uint256 communityTokenDisplayAmount
+) external returns (uint256 pceAmount);
+```
+
+**PCECommunityToken — new internal function:**
+
+```solidity
+/// @notice Burns community token fee from the payer and sends equivalent PCE to the relayer.
+/// @param from The address paying the fee (token holder)
+/// @param relayer The relayer address to receive PCE
+/// @param displayFee The fee amount in community token display units
+function _collectFeeAsPCE(
+    address from,
+    address relayer,
+    uint256 displayFee
+) internal returns (uint256 pceAmount);
+```
+
+**PCECommunityToken — modified functions:**
+
+The following functions replace their `super._transfer(from, _msgSender(), rawFee)` call with `_collectFeeAsPCE(from, _msgSender(), displayFee)`:
+
+- `transferWithAuthorization`
+- `transferFromWithAuthorization`
+- `setInfinityApproveFlagWithAuthorization`
+- `claimVoucherWithAuthorization`
+
+No changes are made to `getMetaTransactionFee()` or `getMetaTransactionFeeWithBaseFee()` — the fee is still denominated and displayed in community token units.
+
+#### Storage
+
+No new storage variables are required. The existing swap rate parameters (`exchangeRate`, `getCurrentFactor()`, `lastModifiedFactor`) are reused for the fee conversion calculation.
+
+#### Events
+
+**PCECommunityToken — new event (replaces `MetaTransactionFeeCollected`):**
+
+```solidity
+event MetaTransactionFeeSwapped(
+    address indexed from,
+    address indexed relayer,
+    uint256 communityTokenFee,
+    uint256 pceFee
+);
+```
+
+**PCEToken — new event:**
+
+```solidity
+event FeeSwappedFromLocalToken(
+    address indexed fromToken,
+    address indexed relayer,
+    uint256 communityTokenAmount,
+    uint256 pceAmount
+);
+```
+
+The existing `MetaTransactionFeeCollected` event is no longer emitted.
+
+#### Fee Swap Algorithm
+
+When `_collectFeeAsPCE(from, relayer, displayFee)` is called:
+
+1. Convert `displayFee` to raw amount: `rawFee = displayBalanceToRawBalance(displayFee)`
+2. Burn community tokens from `from`: `_burn(from, rawFee)`
+3. Call `PCEToken(pceAddress).swapFeeFromLocalToken(address(this), relayer, displayFee)`
+
+When `PCEToken.swapFeeFromLocalToken(fromToken, relayer, communityTokenDisplayAmount)` is called:
+
+1. Verify `msg.sender == fromToken` and `localTokens[fromToken].isExists`
+2. Calculate PCE amount using the same formula as `swapFromLocalToken`:
+   ```
+   pceAmount = communityTokenDisplayAmount
+               × INITIAL_FACTOR / exchangeRate
+               × lastModifiedFactor / target.getCurrentFactor()
+   ```
+3. Transfer PCE to relayer: `_transfer(address(this), relayer, pceAmount)`
+4. **Do NOT** call `target.recordSwapToPCE()` — fee swaps are exempt from daily limits
+5. Emit `FeeSwappedFromLocalToken(fromToken, relayer, communityTokenDisplayAmount, pceAmount)`
+
+#### Special Case: Voucher Claims
+
+In `claimVoucherWithAuthorization`, the fee source is `address(this)` (the contract itself), not an end user. The same `_collectFeeAsPCE(address(this), relayer, displayFee)` call applies — community tokens held by the contract are burned and PCE is sent to the relayer.
+
+### Rationale
+
+**Why auto-swap instead of letting relayers swap manually?**
+Relayers operate infrastructure that serves all communities. Requiring them to manage and swap dozens of community token types creates unnecessary operational overhead. Auto-swap reduces this to zero by giving relayers exactly what they need: PCE.
+
+**Why exempt from daily swap limits?**
+Daily swap limits exist to prevent rapid economic destabilization from large speculative swaps. Meta-transaction fees are fundamentally different: they are small, predictable amounts driven by gas costs. Subjecting them to swap limits would cause meta-transaction failures when limits are exhausted, degrading user experience for all community members. The fee amounts are too small to pose any destabilization risk.
+
+**Why burn-and-transfer instead of transfer-and-swap?**
+Burning community tokens in the fee payer's context and transferring PCE from the PCEToken contract mirrors the existing `swapFromLocalToken` mechanic. This maintains consistency in how community token supply and PCE reserves interact.
+
+**Why replace `MetaTransactionFeeCollected` with a new event?**
+The semantics of the fee collection have changed: the relayer now receives PCE, not community tokens. A new event with explicit `pceFee` field provides accurate information for indexers and avoids misinterpretation of legacy event data.
+
+### Backwards Compatibility
+
+**Breaking changes:**
+
+- **Relayer fee denomination**: Relayers now receive PCE instead of community tokens. Relayer software MUST be updated to expect PCE balance increases rather than community token balance increases.
+- **Event change**: `MetaTransactionFeeCollected` is replaced by `MetaTransactionFeeSwapped`. Off-chain indexers and analytics that consume this event MUST be updated.
+
+**Non-breaking:**
+
+- `getMetaTransactionFee()` and `getMetaTransactionFeeWithBaseFee()` return values are unchanged (community token display units). Client-side fee estimation requires no changes.
+- User experience is unchanged — users still pay the same fee amount in community tokens.
+- No storage layout changes.
+
+### Test Cases
+
+All examples use `INITIAL_FACTOR = 10^18`.
+
+**Case 1: Standard fee swap**
+- Community token: exchangeRate = `2e18`, getCurrentFactor = `1e18`
+- PCEToken: lastModifiedFactor = `1e18`
+- Meta-transaction fee: `0.002` community tokens (displayFee)
+- PCE calculation: `0.002 × 1e18 / 2e18 × 1e18 / 1e18 = 0.001` PCE
+- Result: `0.002` community tokens burned from user, `0.001` PCE transferred to relayer
+- Daily swap counters: unchanged
+
+**Case 2: Fee swap with demurrage factors**
+- Community token: exchangeRate = `2e18`, getCurrentFactor = `0.99e18` (1% demurrage applied)
+- PCEToken: lastModifiedFactor = `0.98e18` (2% demurrage applied)
+- Meta-transaction fee: `0.002` community tokens (displayFee)
+- PCE calculation: `0.002 × 1e18 / 2e18 × 0.98e18 / 0.99e18 = 0.000990909...` PCE
+- Result: community tokens burned, PCE transferred with factor adjustment
+
+**Case 3: Fee swap does not affect daily limits**
+- Daily global swap limit: `1000` community tokens, already used: `1000` (exhausted)
+- Daily individual swap limit: `100` community tokens, already used: `100` (exhausted)
+- Meta-transaction fee: `0.002` community tokens
+- Result: Fee swap succeeds. Regular `swapFromLocalToken` would revert with "Exceeds daily swap limit", but fee swap bypasses limit checks entirely.
+
+**Case 4: Voucher claim fee swap**
+- Community token contract holds `10` community tokens (voucher balance)
+- Claimer calls `claimVoucherWithAuthorization`
+- Fee: `0.002` community tokens
+- Result: `0.002` community tokens burned from contract balance, equivalent PCE sent to relayer. Claimer receives remaining voucher amount minus fee.
+
+**Case 5: Insufficient PCE reserves**
+- PCEToken contract holds `0` PCE (all reserves depleted)
+- Meta-transaction fee swap attempts to transfer PCE to relayer
+- Result: Transaction reverts. The meta-transaction cannot be executed.
+
+### Security Considerations
+
+**Swap limit bypass is restricted to fee amounts**: The `swapFeeFromLocalToken` function can only be called by registered community token contracts (`msg.sender == fromToken`). The community token contracts only call this function during fee collection in `*WithAuthorization` functions, where the fee amount is deterministically calculated from gas parameters set by the contract owner. An attacker cannot inflate the fee amount to exploit the limit bypass.
+
+**PCE reserve depletion**: Fee swaps draw from the same PCE reserves as regular swaps. In extreme scenarios with very high meta-transaction volume across many communities, cumulative fee swaps could deplete PCE reserves faster than expected. However, individual fee amounts are negligible compared to regular swap volumes (typically < 0.01 PCE per transaction). Implementations SHOULD monitor PCE reserve levels.
+
+**Reentrancy**: `_collectFeeAsPCE` burns tokens (state change) before making an external call to `PCEToken.swapFeeFromLocalToken`. The PCEToken function performs a `_transfer` (state change). This follows the checks-effects-interactions pattern within each contract. Implementations SHOULD use a reentrancy guard on `swapFeeFromLocalToken` as defense-in-depth.
+
+**Rounding**: The fee undergoes two conversions: PCE → community token (in `getMetaTransactionFee`) → PCE (in `swapFeeFromLocalToken`). Due to integer division, the relayer may receive slightly less PCE than the theoretical gas cost. The rounding error is bounded by 1 wei per conversion step and is negligible in practice.
+
+**Atomicity**: The burn and PCE transfer occur in the same transaction. If the PCE transfer fails (e.g., insufficient reserves), the entire meta-transaction reverts. This prevents a state where community tokens are burned but no PCE is received.
+
+### Notes
+
+- **Scope of impact**: Requires upgrades to both PCEToken and PCECommunityToken contracts
+- **Interaction with PIP-2**: If PIP-2 (Community Treasury Wallet) is implemented, fee swaps reduce the PCEToken contract's PCE balance but do not modify `depositedPCEToken` for the community. This is consistent with how regular `swapFromLocalToken` operates — `depositedPCEToken` tracks capital operations only, not swap activity.
+- **Out of scope**: Relayer fee margin configuration (e.g., markup for profit) is not addressed. Native token conversion (PCE → MATIC/POL) for actual gas payment remains the relayer's responsibility.
+- **Dependencies**: None (builds on existing meta-transaction and swap infrastructure)


### PR DESCRIPTION
## Summary

- Add PIP-13: Meta-Transaction Fee Auto-Swap to PCE
- Implementation: https://github.com/peacecoin-protocol/core/pull/29
- Tally Proposal: https://www.tally.xyz/gov/pce-dao/draft/2811459409178264786

## Abstract

This proposal changes meta-transaction fee settlement from direct community token transfer to automatic PCE conversion. When a relayer executes a meta-transaction, the fee collected from the user in community tokens is burned and the equivalent amount of PCE is transferred to the relayer. This swap is exempt from daily swap limits.

### Key Points

- **Auto-Swap**: Meta-transaction fees are burned as community tokens and equivalent PCE is transferred to the relayer via `swapFeeFromLocalToken`
- **Swap Limit Exemption**: Fee swaps bypass both daily global and individual swap limits, preventing meta-transaction failures when limits are exhausted
- **Relayer Simplification**: Relayers receive PCE directly instead of accumulating various community tokens across communities
- **Scope**: Requires upgrades to both PCEToken and PCECommunityToken contracts

---

<details>
<summary>日本語版（参考）</summary>

## PIP-13: メタトランザクション手数料のPCE自動変換

### Abstract（概要）

メタトランザクション手数料の決済方式を、コミュニティトークンの直接転送からPCEへの自動変換に変更する。リレイヤーがメタトランザクションを実行する際、ユーザーから徴収したコミュニティトークン手数料をburnし、同等のPCEをリレイヤーに転送する。このスワップは日次スワップ制限の対象外とする。

### Motivation

現在の設計では、メタトランザクション手数料はトランザクション対象のコミュニティトークンで徴収され、リレイヤーに直接転送される。これには2つの問題がある：

1. **リレイヤーのトークン断片化**: リレイヤーは複数のコミュニティにわたって多種多様なコミュニティトークンを蓄積する。リレイヤーがガスコストを賄うために必要なのはPCEであり、コミュニティトークンのポートフォリオではない。
2. **レート制限付きの手動スワップ負担**: 蓄積したコミュニティトークンをPCEに変換するには、トークン種別ごとに`swapFromLocalToken`を呼び出す必要があり、日次スワップ制限の制約を受ける。

### Specification

#### インターフェース

**PCEToken — 新関数:**

```solidity
function swapFeeFromLocalToken(
    address fromToken,
    address relayer,
    uint256 communityTokenDisplayAmount
) external returns (uint256 pceAmount);
```

**PCECommunityToken — 新内部関数:**

```solidity
function _collectFeeAsPCE(
    address from,
    address relayer,
    uint256 displayFee
) internal returns (uint256 pceAmount);
```

#### 手数料スワップアルゴリズム

1. ユーザーからコミュニティトークンをburn
2. `swapFromLocalToken`と同じ計算式でPCE量を算出
3. PCEをリレイヤーに転送
4. `recordSwapToPCE()`を**呼び出さない** — 日次制限の対象外

#### 変更される関数

- `transferWithAuthorization`
- `transferFromWithAuthorization`
- `setInfinityApproveFlagWithAuthorization`
- `claimVoucherWithAuthorization`

### Rationale（設計根拠）

- **なぜ自動スワップか？** リレイヤーは全コミュニティにサービスを提供するインフラ。数十種類のコミュニティトークンの管理を不要にする。
- **なぜ日次制限から免除か？** 手数料はガスコストに基づく少額かつ予測可能な金額。制限対象にするとメタトランザクション失敗を引き起こす。
- **なぜburn-and-transferか？** 既存の`swapFromLocalToken`のメカニズムと一致し、一貫性を維持。

### Security Considerations（セキュリティ考慮事項）

- スワップ制限バイパスは登録済みコミュニティトークンからの手数料額に限定
- PCEリザーブ枯渇リスク（手数料額は無視できる程度）
- リエントランシー（checks-effects-interactions パターン準拠）
- 丸め誤差（変換ステップごとに1 weiに制限）

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)