### PR TITLE
PIP-12: Community Treasury Wallet and Capital Operations

### DIFF
--- a/PIPs/pip-12.md
+++ b/PIPs/pip-12.md
@@ -13,7 +13,7 @@ replaces: []
 
 ### Abstract
 
-This proposal introduces a treasury wallet mechanism for PCECommunityToken, enabling capital increase and decrease operations that adjust the swap rate (`exchangeRate`) by managing PCE reserves. A new `TREASURY_MANAGER_ROLE` governs access to these operations.
+This proposal introduces a treasury wallet mechanism for PCECommunityToken, enabling capital increase and decrease operations that adjust the swap rate (`exchangeRate`). Capital increase adds PCE reserves from the treasury wallet. Capital decrease mints new community tokens and distributes them proportionally to all existing holders via a rebase factor, without withdrawing PCE from reserves. A new `TREASURY_MANAGER_ROLE` governs access to these operations.
 
 ### Motivation
 
@@ -21,8 +21,8 @@ In the current PCECommunityToken design, the swap rate (`exchangeRate`) is fixed
 
 This proposal enables:
 - Community operators to add PCE reserves to increase token value (capital increase)
-- Community operators to withdraw PCE reserves for operational funds (capital decrease)
-- Swap rate adjustment through PCE reserve management
+- Community operators to expand token supply via proportional distribution to all holders (capital decrease)
+- Swap rate adjustment through reserve management and supply expansion
 
 ### Specification
 
@@ -36,18 +36,17 @@ The following interfaces are added to the respective contracts.
 function initializeTreasury(address wallet) external;
 function setTreasuryWallet(address wallet) external;
 function capitalIncrease(uint256 pceAmount) external;
-function capitalDecrease(uint256 pceAmount) external;
+function capitalDecrease(uint256 mintAmount) external;
 function hasRole(bytes32 role, address account) external view returns (bool);
 function grantTreasuryManagerRole(address account) external;
 function revokeTreasuryManagerRole(address account) external;
 function treasuryWallet() external view returns (address);
 ```
 
-**PCEToken — new functions:**
+**PCEToken — new function:**
 
 ```solidity
 function addCapital(address communityToken, uint256 pceAmount, address treasuryWallet) external;
-function removeCapital(address communityToken, uint256 pceAmount, address treasuryWallet) external;
 ```
 
 #### Storage
@@ -58,6 +57,7 @@ The following storage variables are added to `PCECommunityToken`:
 address public treasuryWallet;
 bytes32 public constant TREASURY_MANAGER_ROLE = keccak256("TREASURY_MANAGER_ROLE");
 mapping(bytes32 => mapping(address => bool)) private _roles;
+uint256 public rebaseFactor; // initialized to INITIAL_FACTOR (1e18)
 ```
 
 All new variables are appended after existing storage. No existing storage slots are modified.
@@ -67,7 +67,7 @@ All new variables are appended after existing storage. No existing storage slots
 ```solidity
 event TreasuryWalletSet(address indexed wallet);
 event CapitalIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
-event CapitalDecreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
+event CapitalDecreased(uint256 mintAmount, uint256 oldExchangeRate, uint256 newExchangeRate, uint256 oldRebaseFactor, uint256 newRebaseFactor);
 event TreasuryManagerRoleGranted(address indexed account);
 event TreasuryManagerRoleRevoked(address indexed account);
 ```
@@ -85,23 +85,28 @@ Transfers PCE from the treasury wallet to the PCEToken contract and adjusts the 
 
 #### Capital Decrease
 
-Withdraws PCE reserves from the PCEToken contract to the treasury wallet and adjusts the swap rate upward, decreasing the value of existing community tokens.
+Mints new community tokens and distributes them proportionally to all existing holders by adjusting a rebase factor. No PCE is withdrawn from reserves. The swap rate is adjusted upward to reflect the increased token supply, decreasing the PCE-equivalent value per token.
 
-1. `pceAmount` MUST be strictly less than `depositedPCEToken` (full withdrawal is not permitted; see Rationale)
-2. `pceAmount` PCE is transferred from the PCEToken contract to the treasury wallet
-3. `depositedPCEToken` is decreased by `pceAmount`
-4. `exchangeRate` is adjusted: `newRate = oldRate * oldDeposited / (oldDeposited - pceAmount)`
-5. No community tokens are burned
-6. Emits `CapitalDecreased`
+1. `mintAmount` is specified in community token display units
+2. `rebaseFactor` is adjusted: `newRebaseFactor = oldRebaseFactor * (totalDisplaySupply + mintAmount) / totalDisplaySupply`
+3. All holders' display balances increase proportionally: `newDisplayBalance = oldDisplayBalance * newRebaseFactor / oldRebaseFactor`
+4. `exchangeRate` is adjusted: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`
+5. `depositedPCEToken` is unchanged
+6. No PCE moves
+7. Emits `CapitalDecreased`
+
+The display balance calculation incorporates the rebase factor: `displayBalance = rawBalance * INITIAL_FACTOR / getCurrentFactor() * rebaseFactor / INITIAL_FACTOR`
 
 #### Symmetry of Capital Operations
 
 | | Capital Increase | Capital Decrease |
 |---|---|---|
-| PCE flow | Treasury → Contract | Contract → Treasury |
-| `depositedPCEToken` | Increases | Decreases |
+| PCE flow | Treasury → Contract | None |
+| `depositedPCEToken` | Increases | Unchanged |
 | `exchangeRate` | Adjusted downward (token value ↑) | Adjusted upward (token value ↓) |
-| Token mint/burn | None | None |
+| Token supply | Unchanged | Increases (via rebase factor) |
+| `rebaseFactor` | Unchanged | Increases |
+| Holder balances | Unchanged | All increase proportionally |
 
 #### Role Management
 
@@ -113,14 +118,17 @@ Withdraws PCE reserves from the PCEToken contract to the treasury wallet and adj
 
 ### Rationale
 
-**Why adjust exchangeRate instead of minting/burning community tokens?**
-Minting would dilute existing holders. Burning would require holders to surrender tokens. Adjusting `exchangeRate` changes the PCE-equivalent value of all community tokens uniformly without affecting token balances or total supply.
+**Why adjust exchangeRate for capital increase instead of minting community tokens?**
+Minting would dilute existing holders. Adjusting `exchangeRate` changes the PCE-equivalent value of all community tokens uniformly without affecting token balances or total supply.
+
+**Why use rebase-based distribution for capital decrease instead of withdrawing PCE?**
+Withdrawing PCE to a treasury wallet depletes the reserves backing the community token. The rebase approach keeps PCE reserves intact and instead expands the token supply proportionally. This ensures no value leaves the system — the economic effect is a uniform supply expansion (analogous to a stock split), preserving each holder's proportional share while adjusting the per-token value.
 
 **Why a custom role system instead of OpenZeppelin AccessControl?**
 PCECommunityToken uses a Beacon proxy pattern. Inheriting AccessControl would introduce new base contract storage slots that conflict with the existing storage layout of deployed proxies. A lightweight mapping-based role system avoids this.
 
-**Why is full withdrawal not permitted?**
-If `depositedPCEToken` reaches zero, the exchange rate formula `oldRate * oldDeposited / (oldDeposited - pceAmount)` produces a division by zero. Additionally, resuming from zero via capital increase would produce `oldRate * 0 / (0 + pceAmount) = 0`, corrupting the exchange rate. Community dissolution (full withdrawal of reserves) involves broader considerations and should be addressed in a separate proposal.
+**Why use a factor-based rebase instead of iterating holders?**
+On-chain iteration over all token holders is prohibitively gas-expensive and requires maintaining an enumerable holder set. A factor-based approach achieves O(1) gas cost regardless of holder count, consistent with the existing demurrage factor pattern in PCECommunityToken.
 
 ### Backwards Compatibility
 
@@ -136,16 +144,17 @@ All examples use `INITIAL_FACTOR = 10^18`.
 - Result: `depositedPCEToken = 150e18`, `exchangeRate = 1e18 * 100e18 / 150e18 = 0.667e18`
 - Effect: A user swapping 1 community token now receives more PCE (rate decreased → each community token is worth more PCE)
 
-**Case 2: Capital Decrease**
-- Initial state: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`
-- Action: `capitalDecrease(25e18)`
-- Result: `depositedPCEToken = 75e18`, `exchangeRate = 1e18 * 100e18 / 75e18 = 1.333e18`
-- Effect: A user swapping 1 community token now receives less PCE (rate increased → each community token is worth less PCE)
+**Case 2: Capital Decrease (supply expansion)**
+- Initial state: `totalDisplaySupply = 200e18`, `exchangeRate = 1e18`, `rebaseFactor = 1e18`
+- Action: `capitalDecrease(50e18)` (mint 50 tokens)
+- Result: `rebaseFactor = 1e18 * (200e18 + 50e18) / 200e18 = 1.25e18`, `exchangeRate = 1e18 * 1.25e18 / 1e18 = 1.25e18`
+- Effect: All holders' display balances increase by 25%. Each community token is now worth less PCE (rate increased). `depositedPCEToken` unchanged. Each holder's total PCE-equivalent value unchanged.
 
-**Case 3: Full withdrawal rejected**
-- Initial state: `depositedPCEToken = 100e18`
-- Action: `capitalDecrease(100e18)`
-- Result: Reverts (full withdrawal is not permitted)
+**Case 3: Capital Decrease preserves proportional ownership**
+- Initial state: Alice holds 100 tokens (50%), Bob holds 100 tokens (50%), `totalDisplaySupply = 200e18`
+- Action: `capitalDecrease(100e18)` (mint 100 tokens)
+- Result: Alice holds 150 tokens (50%), Bob holds 150 tokens (50%), `totalDisplaySupply = 300e18`
+- Effect: Both holders' proportional ownership is preserved
 
 **Case 4: Unauthorized access**
 - Action: Non-treasury-manager calls `capitalIncrease(10e18)`
@@ -153,11 +162,11 @@ All examples use `INITIAL_FACTOR = 10^18`.
 
 ### Security Considerations
 
-**Compromised TREASURY_MANAGER_ROLE**: A malicious treasury manager could withdraw most PCE reserves via repeated `capitalDecrease` calls, severely devaluing the community token. Communities SHOULD use multisig wallets or DAO governance to manage the treasury manager role. However, the governance model is outside the scope of this proposal and is left to each community's discretion.
+**Compromised TREASURY_MANAGER_ROLE**: A malicious treasury manager could repeatedly call `capitalDecrease` to inflate the token supply, devaluing each token's PCE-equivalent worth. However, since no PCE leaves the system and all holders are diluted equally, the attack surface is limited to exchange rate manipulation. Communities SHOULD use multisig wallets or DAO governance to manage the treasury manager role. However, the governance model is outside the scope of this proposal and is left to each community's discretion.
 
-**Front-running**: A capital decrease transaction in the mempool could be front-run by a user calling `swapFromLocalToken` at the current (more favorable) rate before the rate adjustment takes effect. Mitigation strategies (e.g., commit-reveal, private mempools) are outside the scope of this proposal.
+**Front-running**: A capital decrease transaction in the mempool could be front-run by a user calling `swapFromLocalToken` at the current (more favorable) rate before the rate adjustment takes effect. Since capital decrease does not remove PCE from reserves, the impact is limited to rate arbitrage. Mitigation strategies (e.g., commit-reveal, private mempools) are outside the scope of this proposal.
 
-**Reentrancy**: `addCapital` uses `transferFrom` (external call) and `removeCapital` uses `transfer` (external call). Implementations MUST follow the checks-effects-interactions pattern or use a reentrancy guard to prevent reentrancy attacks.
+**Reentrancy**: `addCapital` uses `transferFrom` (external call). Capital decrease is purely internal (factor adjustment, no external calls). Implementations MUST follow the checks-effects-interactions pattern or use a reentrancy guard on `addCapital` to prevent reentrancy attacks.
 
 **Integer overflow/underflow**: The exchange rate formula uses multiplication before division. Implementations MUST use `Math.mulDiv` or equivalent safe math to prevent precision loss and overflow.
 
@@ -165,5 +174,5 @@ All examples use `INITIAL_FACTOR = 10^18`.
 
 - **Scope of impact**: Requires upgrades to both PCEToken and PCECommunityToken contracts
 - **Alternatives considered**: OpenZeppelin AccessControl was considered but rejected due to storage layout conflicts (see Rationale)
-- **Out of scope**: Treasury wallet management (e.g., multisig, DAO governance) is left to each community's discretion. Community dissolution (full reserve withdrawal) should be addressed in a separate proposal.
+- **Out of scope**: Treasury wallet management (e.g., multisig, DAO governance) is left to each community's discretion. Community dissolution should be addressed in a separate proposal.
 - **Dependencies**: None (builds on the existing UUPS/Beacon proxy architecture)

--- a/PIPs/pip-12.md
+++ b/PIPs/pip-12.md
@@ -1,6 +1,6 @@
 ---
 pip: 12
-title: Community Treasury Wallet and Capital Operations
+title: Community Treasury Wallet and Token Value Operations
 proposer: CHIBA Masahiro (@nihen)
 status: Draft
 type: Core
@@ -9,19 +9,19 @@ requires: []
 replaces: []
 ---
 
-## PIP-12: Community Treasury Wallet and Capital Operations
+## PIP-12: Community Treasury Wallet and Token Value Operations
 
 ### Abstract
 
-This proposal introduces a treasury wallet mechanism for PCECommunityToken, enabling capital increase and decrease operations that adjust the swap rate (`exchangeRate`). Capital increase adds PCE reserves from the treasury wallet. Capital decrease mints new community tokens and distributes them proportionally to all existing holders via a rebase factor, without withdrawing PCE from reserves. A new `TREASURY_MANAGER_ROLE` governs access to these operations.
+This proposal introduces a treasury wallet mechanism for PCECommunityToken, enabling token value increase and token split operations that adjust the swap rate (`exchangeRate`). Token value increase adds PCE reserves from the treasury wallet. Token split mints new community tokens and distributes them proportionally to all existing holders via a rebase factor, without withdrawing PCE from reserves. A new `RATE_MANAGER_ROLE` governs access to these operations.
 
 ### Motivation
 
 In the current PCECommunityToken design, the swap rate (`exchangeRate`) is fixed at token creation and cannot be changed afterward. This rigidity prevents communities from adjusting token value in response to growth, funding needs, or changing economic conditions.
 
 This proposal enables:
-- Community operators to add PCE reserves to increase token value (capital increase)
-- Community operators to expand token supply via proportional distribution to all holders (capital decrease)
+- Community operators to add PCE reserves to increase token value (token value increase)
+- Community operators to expand token supply via proportional distribution to all holders (token split)
 - Swap rate adjustment through reserve management and supply expansion
 
 ### Specification
@@ -35,18 +35,18 @@ The following interfaces are added to the respective contracts.
 ```solidity
 function initializeTreasury(address wallet) external;
 function setTreasuryWallet(address wallet) external;
-function capitalIncrease(uint256 pceAmount) external;
-function capitalDecrease(uint256 mintAmount) external;
+function increaseTokenValue(uint256 pceAmount) external;
+function splitToken(uint256 mintAmount) external;
 function hasRole(bytes32 role, address account) external view returns (bool);
-function grantTreasuryManagerRole(address account) external;
-function revokeTreasuryManagerRole(address account) external;
+function grantRateManagerRole(address account) external;
+function revokeRateManagerRole(address account) external;
 function treasuryWallet() external view returns (address);
 ```
 
 **PCEToken — new function:**
 
 ```solidity
-function addCapital(address communityToken, uint256 pceAmount, address treasuryWallet) external;
+function addReserve(address communityToken, uint256 pceAmount, address treasuryWallet) external;
 ```
 
 #### Storage
@@ -55,7 +55,7 @@ The following storage variables are added to `PCECommunityToken`:
 
 ```solidity
 address public treasuryWallet;
-bytes32 public constant TREASURY_MANAGER_ROLE = keccak256("TREASURY_MANAGER_ROLE");
+bytes32 public constant RATE_MANAGER_ROLE = keccak256("RATE_MANAGER_ROLE");
 mapping(bytes32 => mapping(address => bool)) private _roles;
 uint256 public rebaseFactor; // initialized to INITIAL_FACTOR (1e18)
 ```
@@ -66,13 +66,13 @@ All new variables are appended after existing storage. No existing storage slots
 
 ```solidity
 event TreasuryWalletSet(address indexed wallet);
-event CapitalIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
-event CapitalDecreased(uint256 mintAmount, uint256 oldExchangeRate, uint256 newExchangeRate, uint256 oldRebaseFactor, uint256 newRebaseFactor);
-event TreasuryManagerRoleGranted(address indexed account);
-event TreasuryManagerRoleRevoked(address indexed account);
+event TokenValueIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
+event TokenSplit(uint256 mintAmount, uint256 oldExchangeRate, uint256 newExchangeRate, uint256 oldRebaseFactor, uint256 newRebaseFactor);
+event RateManagerRoleGranted(address indexed account);
+event RateManagerRoleRevoked(address indexed account);
 ```
 
-#### Capital Increase
+#### Token Value Increase
 
 Transfers PCE from the treasury wallet to the PCEToken contract and adjusts the swap rate downward, increasing the value of existing community tokens.
 
@@ -81,9 +81,9 @@ Transfers PCE from the treasury wallet to the PCEToken contract and adjusts the 
 3. `depositedPCEToken` is increased by `pceAmount`
 4. `exchangeRate` is adjusted: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`
 5. No community tokens are minted
-6. Emits `CapitalIncreased`
+6. Emits `TokenValueIncreased`
 
-#### Capital Decrease
+#### Token Split
 
 Mints new community tokens and distributes them proportionally to all existing holders by adjusting a rebase factor. No PCE is withdrawn from reserves. The swap rate is adjusted upward to reflect the increased token supply, decreasing the PCE-equivalent value per token.
 
@@ -93,13 +93,13 @@ Mints new community tokens and distributes them proportionally to all existing h
 4. `exchangeRate` is adjusted: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`
 5. `depositedPCEToken` is unchanged
 6. No PCE moves
-7. Emits `CapitalDecreased`
+7. Emits `TokenSplit`
 
 The display balance calculation incorporates the rebase factor: `displayBalance = rawBalance * INITIAL_FACTOR / getCurrentFactor() * rebaseFactor / INITIAL_FACTOR`
 
-#### Symmetry of Capital Operations
+#### Comparison of Operations
 
-| | Capital Increase | Capital Decrease |
+| | Token Value Increase | Token Split |
 |---|---|---|
 | PCE flow | Treasury → Contract | None |
 | `depositedPCEToken` | Increases | Unchanged |
@@ -110,18 +110,18 @@ The display balance calculation incorporates the rebase factor: `displayBalance 
 
 #### Role Management
 
-`TREASURY_MANAGER_ROLE` controls access to `capitalIncrease`, `capitalDecrease`, and `setTreasuryWallet`. The role is managed as follows:
+`RATE_MANAGER_ROLE` controls access to `increaseTokenValue`, `splitToken`, and `setTreasuryWallet`. The role is managed as follows:
 
-- `initializeTreasury(wallet)`: One-time setup. MUST be called by the contract owner. Sets the treasury wallet and grants `TREASURY_MANAGER_ROLE` to `msg.sender`. MUST revert if `treasuryWallet` is already set.
-- `grantTreasuryManagerRole(account)`: Grants the role to `account`. MUST be called by an existing treasury manager.
-- `revokeTreasuryManagerRole(account)`: Revokes the role from `account`. MUST be called by an existing treasury manager.
+- `initializeTreasury(wallet)`: One-time setup. MUST be called by the contract owner. Sets the treasury wallet and grants `RATE_MANAGER_ROLE` to `msg.sender`. MUST revert if `treasuryWallet` is already set.
+- `grantRateManagerRole(account)`: Grants the role to `account`. MUST be called by an existing rate manager.
+- `revokeRateManagerRole(account)`: Revokes the role from `account`. MUST be called by an existing rate manager.
 
 ### Rationale
 
-**Why adjust exchangeRate for capital increase instead of minting community tokens?**
+**Why adjust exchangeRate for token value increase instead of minting community tokens?**
 Minting would dilute existing holders. Adjusting `exchangeRate` changes the PCE-equivalent value of all community tokens uniformly without affecting token balances or total supply.
 
-**Why use rebase-based distribution for capital decrease instead of withdrawing PCE?**
+**Why use rebase-based distribution for token split instead of withdrawing PCE?**
 Withdrawing PCE to a treasury wallet depletes the reserves backing the community token. The rebase approach keeps PCE reserves intact and instead expands the token supply proportionally. This ensures no value leaves the system — the economic effect is a uniform supply expansion (analogous to a stock split), preserving each holder's proportional share while adjusting the per-token value.
 
 **Why a custom role system instead of OpenZeppelin AccessControl?**
@@ -138,35 +138,35 @@ All changes are additive: new functions, new storage variables (appended after e
 
 All examples use `INITIAL_FACTOR = 10^18`.
 
-**Case 1: Capital Increase**
+**Case 1: Token Value Increase**
 - Initial state: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`
-- Action: `capitalIncrease(50e18)`
+- Action: `increaseTokenValue(50e18)`
 - Result: `depositedPCEToken = 150e18`, `exchangeRate = 1e18 * 100e18 / 150e18 = 0.667e18`
 - Effect: A user swapping 1 community token now receives more PCE (rate decreased → each community token is worth more PCE)
 
-**Case 2: Capital Decrease (supply expansion)**
+**Case 2: Token Split (supply expansion)**
 - Initial state: `totalDisplaySupply = 200e18`, `exchangeRate = 1e18`, `rebaseFactor = 1e18`
-- Action: `capitalDecrease(50e18)` (mint 50 tokens)
+- Action: `splitToken(50e18)` (mint 50 tokens)
 - Result: `rebaseFactor = 1e18 * (200e18 + 50e18) / 200e18 = 1.25e18`, `exchangeRate = 1e18 * 1.25e18 / 1e18 = 1.25e18`
 - Effect: All holders' display balances increase by 25%. Each community token is now worth less PCE (rate increased). `depositedPCEToken` unchanged. Each holder's total PCE-equivalent value unchanged.
 
-**Case 3: Capital Decrease preserves proportional ownership**
+**Case 3: Token Split preserves proportional ownership**
 - Initial state: Alice holds 100 tokens (50%), Bob holds 100 tokens (50%), `totalDisplaySupply = 200e18`
-- Action: `capitalDecrease(100e18)` (mint 100 tokens)
+- Action: `splitToken(100e18)` (mint 100 tokens)
 - Result: Alice holds 150 tokens (50%), Bob holds 150 tokens (50%), `totalDisplaySupply = 300e18`
 - Effect: Both holders' proportional ownership is preserved
 
 **Case 4: Unauthorized access**
-- Action: Non-treasury-manager calls `capitalIncrease(10e18)`
+- Action: Non-rate-manager calls `increaseTokenValue(10e18)`
 - Result: Reverts
 
 ### Security Considerations
 
-**Compromised TREASURY_MANAGER_ROLE**: A malicious treasury manager could repeatedly call `capitalDecrease` to inflate the token supply, devaluing each token's PCE-equivalent worth. However, since no PCE leaves the system and all holders are diluted equally, the attack surface is limited to exchange rate manipulation. Communities SHOULD use multisig wallets or DAO governance to manage the treasury manager role. However, the governance model is outside the scope of this proposal and is left to each community's discretion.
+**Compromised RATE_MANAGER_ROLE**: A malicious rate manager could repeatedly call `splitToken` to inflate the token supply, devaluing each token's PCE-equivalent worth. However, since no PCE leaves the system and all holders are diluted equally, the attack surface is limited to exchange rate manipulation. Communities SHOULD use multisig wallets or DAO governance to manage the rate manager role. However, the governance model is outside the scope of this proposal and is left to each community's discretion.
 
-**Front-running**: A capital decrease transaction in the mempool could be front-run by a user calling `swapFromLocalToken` at the current (more favorable) rate before the rate adjustment takes effect. Since capital decrease does not remove PCE from reserves, the impact is limited to rate arbitrage. Mitigation strategies (e.g., commit-reveal, private mempools) are outside the scope of this proposal.
+**Front-running**: A token split transaction in the mempool could be front-run by a user calling `swapFromLocalToken` at the current (more favorable) rate before the rate adjustment takes effect. Since token split does not remove PCE from reserves, the impact is limited to rate arbitrage. Mitigation strategies (e.g., commit-reveal, private mempools) are outside the scope of this proposal.
 
-**Reentrancy**: `addCapital` uses `transferFrom` (external call). Capital decrease is purely internal (factor adjustment, no external calls). Implementations MUST follow the checks-effects-interactions pattern or use a reentrancy guard on `addCapital` to prevent reentrancy attacks.
+**Reentrancy**: `addReserve` uses `transferFrom` (external call). Token split is purely internal (factor adjustment, no external calls). Implementations MUST follow the checks-effects-interactions pattern or use a reentrancy guard on `addReserve` to prevent reentrancy attacks.
 
 **Integer overflow/underflow**: The exchange rate formula uses multiplication before division. Implementations MUST use `Math.mulDiv` or equivalent safe math to prevent precision loss and overflow.
 

--- a/PIPs/pip-12.md
+++ b/PIPs/pip-12.md
@@ -1,7 +1,7 @@
 ---
 pip: 12
 title: Community Treasury Wallet and Capital Operations
-proposer: chiba (on GitHub)
+proposer: CHIBA Masahiro (@nihen)
 status: Draft
 type: Core
 created: 2026-03-13

--- a/PIPs/pip-12.md
+++ b/PIPs/pip-12.md
@@ -1,5 +1,5 @@
 ---
-pip: 2
+pip: 12
 title: Community Treasury Wallet and Capital Operations
 proposer: chiba (on GitHub)
 status: Draft
@@ -9,7 +9,7 @@ requires: []
 replaces: []
 ---
 
-## PIP-2: Community Treasury Wallet and Capital Operations
+## PIP-12: Community Treasury Wallet and Capital Operations
 
 ### Abstract
 

--- a/PIPs/pip-2.md
+++ b/PIPs/pip-2.md
@@ -1,0 +1,169 @@
+---
+pip: 2
+title: Community Treasury Wallet and Capital Operations
+proposer: chiba (on GitHub)
+status: Draft
+type: Core
+created: 2026-03-13
+requires: []
+replaces: []
+---
+
+## PIP-2: Community Treasury Wallet and Capital Operations
+
+### Abstract
+
+This proposal introduces a treasury wallet mechanism for PCECommunityToken, enabling capital increase and decrease operations that adjust the swap rate (`exchangeRate`) by managing PCE reserves. A new `TREASURY_MANAGER_ROLE` governs access to these operations.
+
+### Motivation
+
+In the current PCECommunityToken design, the swap rate (`exchangeRate`) is fixed at token creation and cannot be changed afterward. This rigidity prevents communities from adjusting token value in response to growth, funding needs, or changing economic conditions.
+
+This proposal enables:
+- Community operators to add PCE reserves to increase token value (capital increase)
+- Community operators to withdraw PCE reserves for operational funds (capital decrease)
+- Swap rate adjustment through PCE reserve management
+
+### Specification
+
+#### Interface
+
+The following interfaces are added to the respective contracts.
+
+**PCECommunityToken — new functions:**
+
+```solidity
+function initializeTreasury(address wallet) external;
+function setTreasuryWallet(address wallet) external;
+function capitalIncrease(uint256 pceAmount) external;
+function capitalDecrease(uint256 pceAmount) external;
+function hasRole(bytes32 role, address account) external view returns (bool);
+function grantTreasuryManagerRole(address account) external;
+function revokeTreasuryManagerRole(address account) external;
+function treasuryWallet() external view returns (address);
+```
+
+**PCEToken — new functions:**
+
+```solidity
+function addCapital(address communityToken, uint256 pceAmount, address treasuryWallet) external;
+function removeCapital(address communityToken, uint256 pceAmount, address treasuryWallet) external;
+```
+
+#### Storage
+
+The following storage variables are added to `PCECommunityToken`:
+
+```solidity
+address public treasuryWallet;
+bytes32 public constant TREASURY_MANAGER_ROLE = keccak256("TREASURY_MANAGER_ROLE");
+mapping(bytes32 => mapping(address => bool)) private _roles;
+```
+
+All new variables are appended after existing storage. No existing storage slots are modified.
+
+#### Events
+
+```solidity
+event TreasuryWalletSet(address indexed wallet);
+event CapitalIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
+event CapitalDecreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
+event TreasuryManagerRoleGranted(address indexed account);
+event TreasuryManagerRoleRevoked(address indexed account);
+```
+
+#### Capital Increase
+
+Transfers PCE from the treasury wallet to the PCEToken contract and adjusts the swap rate downward, increasing the value of existing community tokens.
+
+1. The treasury wallet MUST have approved the PCEToken contract for at least `pceAmount` prior to calling
+2. `pceAmount` PCE is transferred from the treasury wallet to the PCEToken contract via `transferFrom`
+3. `depositedPCEToken` is increased by `pceAmount`
+4. `exchangeRate` is adjusted: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`
+5. No community tokens are minted
+6. Emits `CapitalIncreased`
+
+#### Capital Decrease
+
+Withdraws PCE reserves from the PCEToken contract to the treasury wallet and adjusts the swap rate upward, decreasing the value of existing community tokens.
+
+1. `pceAmount` MUST be strictly less than `depositedPCEToken` (full withdrawal is not permitted; see Rationale)
+2. `pceAmount` PCE is transferred from the PCEToken contract to the treasury wallet
+3. `depositedPCEToken` is decreased by `pceAmount`
+4. `exchangeRate` is adjusted: `newRate = oldRate * oldDeposited / (oldDeposited - pceAmount)`
+5. No community tokens are burned
+6. Emits `CapitalDecreased`
+
+#### Symmetry of Capital Operations
+
+| | Capital Increase | Capital Decrease |
+|---|---|---|
+| PCE flow | Treasury → Contract | Contract → Treasury |
+| `depositedPCEToken` | Increases | Decreases |
+| `exchangeRate` | Adjusted downward (token value ↑) | Adjusted upward (token value ↓) |
+| Token mint/burn | None | None |
+
+#### Role Management
+
+`TREASURY_MANAGER_ROLE` controls access to `capitalIncrease`, `capitalDecrease`, and `setTreasuryWallet`. The role is managed as follows:
+
+- `initializeTreasury(wallet)`: One-time setup. MUST be called by the contract owner. Sets the treasury wallet and grants `TREASURY_MANAGER_ROLE` to `msg.sender`. MUST revert if `treasuryWallet` is already set.
+- `grantTreasuryManagerRole(account)`: Grants the role to `account`. MUST be called by an existing treasury manager.
+- `revokeTreasuryManagerRole(account)`: Revokes the role from `account`. MUST be called by an existing treasury manager.
+
+### Rationale
+
+**Why adjust exchangeRate instead of minting/burning community tokens?**
+Minting would dilute existing holders. Burning would require holders to surrender tokens. Adjusting `exchangeRate` changes the PCE-equivalent value of all community tokens uniformly without affecting token balances or total supply.
+
+**Why a custom role system instead of OpenZeppelin AccessControl?**
+PCECommunityToken uses a Beacon proxy pattern. Inheriting AccessControl would introduce new base contract storage slots that conflict with the existing storage layout of deployed proxies. A lightweight mapping-based role system avoids this.
+
+**Why is full withdrawal not permitted?**
+If `depositedPCEToken` reaches zero, the exchange rate formula `oldRate * oldDeposited / (oldDeposited - pceAmount)` produces a division by zero. Additionally, resuming from zero via capital increase would produce `oldRate * 0 / (0 + pceAmount) = 0`, corrupting the exchange rate. Community dissolution (full withdrawal of reserves) involves broader considerations and should be addressed in a separate proposal.
+
+### Backwards Compatibility
+
+All changes are additive: new functions, new storage variables (appended after existing ones), and new events. No existing function signatures or behavior are modified.
+
+### Test Cases
+
+All examples use `INITIAL_FACTOR = 10^18`.
+
+**Case 1: Capital Increase**
+- Initial state: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`
+- Action: `capitalIncrease(50e18)`
+- Result: `depositedPCEToken = 150e18`, `exchangeRate = 1e18 * 100e18 / 150e18 = 0.667e18`
+- Effect: A user swapping 1 community token now receives more PCE (rate decreased → each community token is worth more PCE)
+
+**Case 2: Capital Decrease**
+- Initial state: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`
+- Action: `capitalDecrease(25e18)`
+- Result: `depositedPCEToken = 75e18`, `exchangeRate = 1e18 * 100e18 / 75e18 = 1.333e18`
+- Effect: A user swapping 1 community token now receives less PCE (rate increased → each community token is worth less PCE)
+
+**Case 3: Full withdrawal rejected**
+- Initial state: `depositedPCEToken = 100e18`
+- Action: `capitalDecrease(100e18)`
+- Result: Reverts (full withdrawal is not permitted)
+
+**Case 4: Unauthorized access**
+- Action: Non-treasury-manager calls `capitalIncrease(10e18)`
+- Result: Reverts
+
+### Security Considerations
+
+**Compromised TREASURY_MANAGER_ROLE**: A malicious treasury manager could withdraw most PCE reserves via repeated `capitalDecrease` calls, severely devaluing the community token. Communities SHOULD use multisig wallets or DAO governance to manage the treasury manager role. However, the governance model is outside the scope of this proposal and is left to each community's discretion.
+
+**Front-running**: A capital decrease transaction in the mempool could be front-run by a user calling `swapFromLocalToken` at the current (more favorable) rate before the rate adjustment takes effect. Mitigation strategies (e.g., commit-reveal, private mempools) are outside the scope of this proposal.
+
+**Reentrancy**: `addCapital` uses `transferFrom` (external call) and `removeCapital` uses `transfer` (external call). Implementations MUST follow the checks-effects-interactions pattern or use a reentrancy guard to prevent reentrancy attacks.
+
+**Integer overflow/underflow**: The exchange rate formula uses multiplication before division. Implementations MUST use `Math.mulDiv` or equivalent safe math to prevent precision loss and overflow.
+
+### Notes
+
+- **Scope of impact**: Requires upgrades to both PCEToken and PCECommunityToken contracts
+- **Alternatives considered**: OpenZeppelin AccessControl was considered but rejected due to storage layout conflicts (see Rationale)
+- **Out of scope**: Treasury wallet management (e.g., multisig, DAO governance) is left to each community's discretion. Community dissolution (full reserve withdrawal) should be addressed in a separate proposal.
+- **Dependencies**: None (builds on the existing UUPS/Beacon proxy architecture)


### PR DESCRIPTION
## Summary

- Add PIP-12: Community Treasury Wallet and Token Value Operations
- **PIP full text**: [PIPs/pip-12.md](https://github.com/peacecoin-protocol/PIPs/blob/pip-12/PIPs/pip-12.md)
- Implementation: https://github.com/peacecoin-protocol/core/pull/30
- Tally Proposal: https://www.tally.xyz/gov/pce-dao/draft/2836981928467367426

## Abstract

This proposal introduces a treasury wallet mechanism for PCECommunityToken, enabling token value increase and token split operations that adjust the swap rate (`exchangeRate`). Token value increase adds PCE reserves from the treasury wallet. Token split mints new community tokens and distributes them proportionally to all existing holders via a rebase factor, without withdrawing PCE from reserves. A new `RATE_MANAGER_ROLE` governs access to these operations.

### Key Points

- **Token Value Increase** (`increaseTokenValue`): Transfer PCE from treasury wallet to contract via `transferFrom`, adjusting swap rate downward (token value increases)
- **Token Split** (`splitToken`): Mint new community tokens and distribute proportionally to all existing holders via a rebase factor, adjusting swap rate upward (token value decreases). **No PCE is withdrawn from reserves.** Economically equivalent to a stock split.
- **Role Management**: New `RATE_MANAGER_ROLE` with lightweight mapping-based implementation to avoid storage layout conflicts with Beacon proxy
- **Rebase Factor**: New `rebaseFactor` storage variable enables O(1) gas-cost proportional distribution without iterating holders
- **Asymmetric by design**: Token value increase adds PCE (safe), while token split uses rebase (no PCE withdrawal) — this prevents bypassing daily swap limits
- **Scope**: Requires upgrades to both PCEToken and PCECommunityToken contracts

### Review notes

> ⚠️ **Implementation (core PR #30) needs rework** to match updated spec:
> - `addReserve()` must use `transferFrom` (not internal `_transfer`)
> - Remove `removeCapital()`, implement `splitToken()` with rebase factor
> - Rename all functions/events/roles to match new naming

---

<details><summary>日本語版 PIP 全文</summary>

```
---
pip: 12
title: Community Treasury Wallet and Token Value Operations
proposer: CHIBA Masahiro (@nihen)
status: Draft
type: Core
created: 2026-03-13
requires: []
replaces: []
---
```

## PIP-12: コミュニティ・トレジャリーウォレットとトークン価値操作

### Abstract（要約）

PCECommunityToken にトレジャリーウォレット機能を導入し、スワップレート（`exchangeRate`）を調整する増価・トークン分割操作を可能にする。増価はトレジャリーウォレットからPCE準備金を追加する。トークン分割はリベースファクターを通じて新しいコミュニティトークンを発行し、全既存ホルダーに保有比率に応じて按分配布する。PCE準備金からの引き出しは行わない。新しい `RATE_MANAGER_ROLE` がこれらの操作へのアクセスを制御する。

### Motivation

現在のPCECommunityTokenでは、スワップレート（`exchangeRate`）はコミュニティトークン作成時に固定され、以降変更する手段がない。この硬直性により、コミュニティの成長、資金ニーズ、経済状況の変化に応じたトークン価値の調整ができない。

本提案により:
- コミュニティ運営者がPCE準備金を追加してトークン価値を上げる（増価）
- コミュニティ運営者がトークン供給量を拡大し、全ホルダーに按分配布する（トークン分割）
- 準備金管理と供給量拡大を通じてスワップレートを調整できる

### Specification

#### インターフェース

以下のインターフェースをそれぞれのコントラクトに追加する。

**PCECommunityToken — 新関数:**

```solidity
function initializeTreasury(address wallet) external;
function setTreasuryWallet(address wallet) external;
function increaseTokenValue(uint256 pceAmount) external;
function splitToken(uint256 mintAmount) external;
function hasRole(bytes32 role, address account) external view returns (bool);
function grantRateManagerRole(address account) external;
function revokeRateManagerRole(address account) external;
function treasuryWallet() external view returns (address);
```

**PCEToken — 新関数:**

```solidity
function addReserve(address communityToken, uint256 pceAmount, address treasuryWallet) external;
```

#### ストレージ

`PCECommunityToken` に以下のストレージ変数を追加する:

```solidity
address public treasuryWallet;
bytes32 public constant RATE_MANAGER_ROLE = keccak256("RATE_MANAGER_ROLE");
mapping(bytes32 => mapping(address => bool)) private _roles;
uint256 public rebaseFactor; // INITIAL_FACTOR (1e18) で初期化
```

すべての新変数は既存ストレージの末尾に追加する。既存のストレージスロットは変更しない。

#### イベント

```solidity
event TreasuryWalletSet(address indexed wallet);
event TokenValueIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
event TokenSplit(uint256 mintAmount, uint256 oldExchangeRate, uint256 newExchangeRate, uint256 oldRebaseFactor, uint256 newRebaseFactor);
event RateManagerRoleGranted(address indexed account);
event RateManagerRoleRevoked(address indexed account);
```

#### 増価（Token Value Increase）

トレジャリーウォレットから PCEToken コントラクトへPCEを送金し、スワップレートを下方調整する。既存のコミュニティトークン保有者のトークン価値が上がる。

1. トレジャリーウォレットは事前に PCEToken コントラクトに対して `pceAmount` 以上の approve が必要（MUST）
2. `transferFrom` によりトレジャリーウォレットから PCEToken コントラクトへ `pceAmount` のPCEを送金
3. `depositedPCEToken` を `pceAmount` 増加
4. `exchangeRate` を調整: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`
5. コミュニティトークンのミントなし
6. `TokenValueIncreased` を発行

#### トークン分割（Token Split）

リベースファクターを調整することで新しいコミュニティトークンを発行し、全既存ホルダーに保有比率に応じて按分配布する。PCE準備金からの引き出しは行わない。トークン供給量の増加を反映してスワップレートを上方調整し、トークン1枚あたりのPCE換算価値を下げる。

1. `mintAmount` はコミュニティトークンの表示単位で指定
2. `rebaseFactor` を調整: `newRebaseFactor = oldRebaseFactor * (totalDisplaySupply + mintAmount) / totalDisplaySupply`
3. 全ホルダーの表示残高が按分で増加: `newDisplayBalance = oldDisplayBalance * newRebaseFactor / oldRebaseFactor`
4. `exchangeRate` を調整: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`
5. `depositedPCEToken` は変更なし
6. PCEの移動なし
7. `TokenSplit` を発行

表示残高の計算にリベースファクターを組み込む: `displayBalance = rawBalance * INITIAL_FACTOR / getCurrentFactor() * rebaseFactor / INITIAL_FACTOR`

#### 増価・トークン分割の対称性

| | 増価 | トークン分割 |
|---|---|---|
| PCE移動 | トレジャリー → コントラクト | なし |
| `depositedPCEToken` | 増加 | 変更なし |
| `exchangeRate` | 下方調整（トークン価値↑） | 上方調整（トークン価値↓） |
| トークン供給量 | 変更なし | 増加（リベースファクター経由） |
| `rebaseFactor` | 変更なし | 増加 |
| ホルダー残高 | 変更なし | 全員が按分で増加 |

#### ロール管理

`RATE_MANAGER_ROLE` は `increaseTokenValue`、`splitToken`、`setTreasuryWallet` へのアクセスを制御する。以下のように管理する:

- `initializeTreasury(wallet)`: ワンタイムセットアップ。コントラクトオーナーが呼び出す（MUST）。トレジャリーウォレットを設定し、`msg.sender` に `RATE_MANAGER_ROLE` を付与する。`treasuryWallet` が設定済みの場合は revert しなければならない（MUST）。
- `grantRateManagerRole(account)`: `account` にロールを付与する。既存のレートマネージャーが呼び出す（MUST）。
- `revokeRateManagerRole(account)`: `account` からロールを剥奪する。既存のレートマネージャーが呼び出す（MUST）。

### Rationale（設計根拠）

**なぜ増価では exchangeRate を調整するのか？**
ミントは既存保有者を希薄化する。`exchangeRate` の調整は、トークン残高や総供給量に影響を与えず、すべてのコミュニティトークンのPCE換算価値を均一に変更できる。

**なぜトークン分割でPCE引き出しではなくリベース方式の配布を使うのか？**
トレジャリーウォレットへのPCE引き出しは、コミュニティトークンを裏付ける準備金を枯渇させる。リベース方式はPCE準備金をそのまま維持し、代わりにトークン供給量を按分で拡大する。システムから価値が流出せず、経済的効果は均一な供給量拡大（株式分割に類似）となり、各ホルダーの持分比率を維持しつつトークン1枚あたりの価値を調整する。

**なぜ OpenZeppelin AccessControl ではなく独自ロールシステムか？**
PCECommunityToken は Beacon プロキシパターンを使用している。AccessControl を継承すると、デプロイ済みプロキシの既存ストレージレイアウトと衝突する新しい基底コントラクトのストレージスロットが導入される。軽量なマッピングベースのロールシステムでこれを回避する。

**なぜホルダーを反復処理するのではなくファクターベースのリベースを使うのか？**
オンチェーンで全トークンホルダーを反復処理するのはガスコストが高すぎ、列挙可能なホルダーセットの維持も必要になる。ファクターベース方式はホルダー数に関係なくO(1)のガスコストで実現でき、PCECommunityToken の既存デマレージファクターパターンと一貫している。

### Backwards Compatibility（後方互換性）

すべての変更は追加的: 新関数、新ストレージ変数（既存の末尾に追加）、新イベント。既存の関数シグネチャや動作は変更しない。

### Test Cases（テストケース）

すべての例で `INITIAL_FACTOR = 10^18` を使用する。

**ケース 1: 増価**
- 初期状態: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`
- 操作: `increaseTokenValue(50e18)`
- 結果: `depositedPCEToken = 150e18`, `exchangeRate = 1e18 * 100e18 / 150e18 = 0.667e18`
- 効果: コミュニティトークン1枚あたりのPCE受取額が増加（レート低下 → 各コミュニティトークンのPCE価値が上昇）

**ケース 2: トークン分割（供給量拡大）**
- 初期状態: `totalDisplaySupply = 200e18`, `exchangeRate = 1e18`, `rebaseFactor = 1e18`
- 操作: `splitToken(50e18)`（50トークン発行）
- 結果: `rebaseFactor = 1e18 * (200e18 + 50e18) / 200e18 = 1.25e18`, `exchangeRate = 1e18 * 1.25e18 / 1e18 = 1.25e18`
- 効果: 全ホルダーの表示残高が25%増加。各コミュニティトークンのPCE換算価値は減少（レート上昇）。`depositedPCEToken` は変更なし。各ホルダーのPCE換算総価値は変更なし。

**ケース 3: トークン分割は持分比率を維持する**
- 初期状態: Alice が100トークン(50%)、Bob が100トークン(50%)保有、`totalDisplaySupply = 200e18`
- 操作: `splitToken(100e18)`（100トークン発行）
- 結果: Alice が150トークン(50%)、Bob が150トークン(50%)、`totalDisplaySupply = 300e18`
- 効果: 両ホルダーの持分比率が維持される

**ケース 4: 権限なしアクセス**
- 操作: レートマネージャーでないアカウントが `increaseTokenValue(10e18)` を呼び出し
- 結果: revert

### Security Considerations（セキュリティ考慮事項）

**RATE_MANAGER_ROLE の侵害**: 悪意のあるレートマネージャーは `splitToken` を繰り返し呼び出してトークン供給量を膨張させ、トークン1枚あたりのPCE換算価値を毀損する可能性がある。ただし、PCEはシステムから流出せず全ホルダーが均等に希薄化されるため、攻撃面はexchangeRateの操作に限定される。コミュニティはレートマネージャーロールの管理にマルチシグウォレットやDAOガバナンスを使用すべき（SHOULD）である。ただし、ガバナンスモデルは本提案のスコープ外であり、各コミュニティの判断に委ねる。

**フロントランニング**: メモリプール内のトークン分割トランザクションを、レート調整が適用される前にユーザーが `swapFromLocalToken` を（現在のより有利なレートで）フロントランする可能性がある。トークン分割ではPCE準備金からの引き出しがないため、影響はレートの裁定取引に限定される。緩和策（commit-reveal、プライベートメモリプール等）は本提案のスコープ外である。

**リエントランシー**: `addReserve` は `transferFrom`（外部呼び出し）を使用する。トークン分割は純粋に内部処理（ファクター調整、外部呼び出しなし）。実装は `addReserve` に対して checks-effects-interactions パターンに従うか、リエントランシーガードを使用しなければならない（MUST）。

**整数オーバーフロー/アンダーフロー**: `exchangeRate` の計算式は除算前に乗算を行う。実装は精度損失とオーバーフローを防ぐために `Math.mulDiv` または同等の安全な数学関数を使用しなければならない（MUST）。

### Notes

- **影響範囲**: PCEToken と PCECommunityToken の両コントラクトへのアップグレードが必要
- **代替案**: OpenZeppelin AccessControl の利用も検討したが、ストレージレイアウトの衝突のため不採用（Rationale 参照）
- **スコープ外**: トレジャリーウォレットの管理方法（マルチシグ、DAOガバナンス等）は各コミュニティの判断に委ねる。コミュニティの解散は別の提案で対処すべきである。
- **依存**: なし（既存のUUPS/Beaconプロキシ構成の上に構築）

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
