### PR TITLE
PIP-13: Meta-Transaction Fee Auto-Swap to PCE

### DIFF
--- a/PIPs/pip-13.md
+++ b/PIPs/pip-13.md
@@ -1,5 +1,5 @@
 ---
-pip: 3
+pip: 13
 title: Meta-Transaction Fee Auto-Swap to PCE
 proposer: chiba (on GitHub)
 status: Draft
@@ -9,7 +9,7 @@ requires: []
 replaces: []
 ---
 
-## PIP-3: Meta-Transaction Fee Auto-Swap to PCE
+## PIP-13: Meta-Transaction Fee Auto-Swap to PCE
 
 ### Abstract
 
@@ -204,6 +204,6 @@ All examples use `INITIAL_FACTOR = 10^18`.
 ### Notes
 
 - **Scope of impact**: Requires upgrades to both PCEToken and PCECommunityToken contracts
-- **Interaction with PIP-2**: If PIP-2 (Community Treasury Wallet) is implemented, fee swaps reduce the PCEToken contract's PCE balance but do not modify `depositedPCEToken` for the community. This is consistent with how regular `swapFromLocalToken` operates — `depositedPCEToken` tracks capital operations only, not swap activity.
+- **Interaction with PIP-12**: If PIP-12 (Community Treasury Wallet) is implemented, fee swaps reduce the PCEToken contract's PCE balance but do not modify `depositedPCEToken` for the community. This is consistent with how regular `swapFromLocalToken` operates — `depositedPCEToken` tracks capital operations only, not swap activity.
 - **Out of scope**: Relayer fee margin configuration (e.g., markup for profit) is not addressed. Native token conversion (PCE → MATIC/POL) for actual gas payment remains the relayer's responsibility.
 - **Dependencies**: None (builds on existing meta-transaction and swap infrastructure)

--- a/PIPs/pip-13.md
+++ b/PIPs/pip-13.md
@@ -1,7 +1,7 @@
 ---
 pip: 13
 title: Meta-Transaction Fee Auto-Swap to PCE
-proposer: chiba (on GitHub)
+proposer: CHIBA Masahiro (@nihen)
 status: Draft
 type: Core
 created: 2026-03-13

--- a/PIPs/pip-13.md
+++ b/PIPs/pip-13.md
@@ -204,6 +204,6 @@ All examples use `INITIAL_FACTOR = 10^18`.
 ### Notes
 
 - **Scope of impact**: Requires upgrades to both PCEToken and PCECommunityToken contracts
-- **Interaction with PIP-12**: If PIP-12 (Community Treasury Wallet) is implemented, fee swaps reduce the PCEToken contract's PCE balance but do not modify `depositedPCEToken` for the community. This is consistent with how regular `swapFromLocalToken` operates — `depositedPCEToken` tracks capital operations only, not swap activity.
-- **Out of scope**: Relayer fee margin configuration (e.g., markup for profit) is not addressed. Native token conversion (PCE → MATIC/POL) for actual gas payment remains the relayer's responsibility.
+- **Interaction with PIP-12**: If PIP-12 (Community Treasury Wallet and Capital Operations) is implemented, fee swaps reduce both the PCEToken contract's PCE balance and the community's `depositedPCEToken`. This is consistent with how regular `swapFromLocalToken` operates — both functions decrease `depositedPCEToken` when PCE leaves the contract.
+- **Out of scope**: Relayer fee margin configuration (e.g., markup for profit) is not addressed. Native token conversion (PCE → POL) for actual gas payment remains the relayer's responsibility.
 - **Dependencies**: None (builds on existing meta-transaction and swap infrastructure)

--- a/PIPs/pip-13.md
+++ b/PIPs/pip-13.md
@@ -77,7 +77,7 @@ No new storage variables are required. The existing swap rate parameters (`excha
 
 #### Events
 
-**PCECommunityToken — new event (replaces `MetaTransactionFeeCollected`):**
+**PCECommunityToken — new event (emitted alongside the existing `MetaTransactionFeeCollected`):**
 
 ```solidity
 event MetaTransactionFeeSwapped(
@@ -99,7 +99,7 @@ event FeeSwappedFromLocalToken(
 );
 ```
 
-The existing `MetaTransactionFeeCollected` event is no longer emitted.
+The existing `MetaTransactionFeeCollected(from, to, displayFee, rawFee)` event continues to be emitted on every fee collection. Its semantics — "the payer `from` was charged `displayFee` / `rawFee` community tokens for a meta-transaction relayed by `to`" — are unchanged: only the relayer's settlement asset has changed (PCE instead of community tokens), and that detail is surfaced via the new `MetaTransactionFeeSwapped` event.
 
 #### Fee Swap Algorithm
 
@@ -108,6 +108,8 @@ When `_collectFeeAsPCE(from, relayer, displayFee)` is called:
 1. Convert `displayFee` to raw amount: `rawFee = displayBalanceToRawBalance(displayFee)`
 2. Burn community tokens from `from`: `_burn(from, rawFee)`
 3. Call `PCEToken(pceAddress).swapFeeFromLocalToken(address(this), relayer, displayFee)`
+4. Emit `MetaTransactionFeeCollected(from, relayer, displayFee, rawFee)` (preserved for backward compatibility)
+5. Emit `MetaTransactionFeeSwapped(from, relayer, displayFee, pceAmount)`
 
 When `PCEToken.swapFeeFromLocalToken(fromToken, relayer, communityTokenDisplayAmount)` is called:
 
@@ -137,18 +139,18 @@ Daily swap limits exist to prevent rapid economic destabilization from large spe
 **Why burn-and-transfer instead of transfer-and-swap?**
 Burning community tokens in the fee payer's context and transferring PCE from the PCEToken contract mirrors the existing `swapFromLocalToken` mechanic. This maintains consistency in how community token supply and PCE reserves interact.
 
-**Why replace `MetaTransactionFeeCollected` with a new event?**
-The semantics of the fee collection have changed: the relayer now receives PCE, not community tokens. A new event with explicit `pceFee` field provides accurate information for indexers and avoids misinterpretation of legacy event data.
+**Why add `MetaTransactionFeeSwapped` instead of replacing `MetaTransactionFeeCollected`?**
+The fee-collection semantics that `MetaTransactionFeeCollected` describes — *the payer was charged `displayFee` / `rawFee` community tokens for a meta-transaction relayed by `to`* — are unchanged by this PIP. Existing indexers that consume the event to track fee burden per payer remain correct. The new `MetaTransactionFeeSwapped` event additionally surfaces the PCE amount the relayer received, which is information the original event cannot express. Emitting both events keeps existing indexers working while letting new consumers observe the PCE settlement explicitly.
 
 ### Backwards Compatibility
 
 **Breaking changes:**
 
 - **Relayer fee denomination**: Relayers now receive PCE instead of community tokens. Relayer software MUST be updated to expect PCE balance increases rather than community token balance increases.
-- **Event change**: `MetaTransactionFeeCollected` is replaced by `MetaTransactionFeeSwapped`. Off-chain indexers and analytics that consume this event MUST be updated.
 
 **Non-breaking:**
 
+- `MetaTransactionFeeCollected(from, to, displayFee, rawFee)` is still emitted on every meta-transaction fee collection, with the same signature and semantics (payer-side fee burden). Off-chain indexers consuming this event continue to work without changes. Indexers that additionally need the PCE amount paid to the relayer can subscribe to the new `MetaTransactionFeeSwapped` event.
 - `getMetaTransactionFee()` and `getMetaTransactionFeeWithBaseFee()` return values are unchanged (community token display units). Client-side fee estimation requires no changes.
 - User experience is unchanged — users still pay the same fee amount in community tokens.
 - No storage layout changes.

--- a/PIPs/pip-3.md
+++ b/PIPs/pip-3.md
@@ -1,0 +1,209 @@
+---
+pip: 3
+title: Meta-Transaction Fee Auto-Swap to PCE
+proposer: chiba (on GitHub)
+status: Draft
+type: Core
+created: 2026-03-13
+requires: []
+replaces: []
+---
+
+## PIP-3: Meta-Transaction Fee Auto-Swap to PCE
+
+### Abstract
+
+This proposal changes meta-transaction fee settlement from direct community token transfer to automatic PCE conversion. When a relayer executes a meta-transaction, the fee collected from the user in community tokens is burned and the equivalent amount of PCE is transferred to the relayer. This swap is exempt from daily swap limits.
+
+### Motivation
+
+In the current design, meta-transaction fees are collected in the community token being transacted and transferred directly to the relayer (`_msgSender()`). This creates two problems:
+
+1. **Relayer token fragmentation**: Relayers accumulate many types of community tokens across communities. These tokens have limited immediate utility — relayers need PCE (or native tokens) to cover gas costs, not a portfolio of community tokens.
+
+2. **Manual swap burden with rate limits**: To convert accumulated community tokens to PCE, relayers must call `swapFromLocalToken` for each token type, subject to daily global and individual swap limits. During high-activity periods, relayers may be unable to swap their earned fees due to exhausted limits.
+
+This proposal solves both problems by automatically converting fees to PCE at the point of collection, exempt from swap limits.
+
+### Specification
+
+#### Interface
+
+**PCEToken — new function:**
+
+```solidity
+/// @notice Swaps community token fee to PCE and transfers to relayer.
+///         Only callable by the community token contract itself.
+///         Exempt from daily swap limits.
+/// @param fromToken The community token contract address (must equal msg.sender)
+/// @param relayer The relayer address to receive PCE
+/// @param communityTokenDisplayAmount The fee amount in community token display units
+/// @return pceAmount The amount of PCE transferred to the relayer
+function swapFeeFromLocalToken(
+    address fromToken,
+    address relayer,
+    uint256 communityTokenDisplayAmount
+) external returns (uint256 pceAmount);
+```
+
+**PCECommunityToken — new internal function:**
+
+```solidity
+/// @notice Burns community token fee from the payer and sends equivalent PCE to the relayer.
+/// @param from The address paying the fee (token holder)
+/// @param relayer The relayer address to receive PCE
+/// @param displayFee The fee amount in community token display units
+function _collectFeeAsPCE(
+    address from,
+    address relayer,
+    uint256 displayFee
+) internal returns (uint256 pceAmount);
+```
+
+**PCECommunityToken — modified functions:**
+
+The following functions replace their `super._transfer(from, _msgSender(), rawFee)` call with `_collectFeeAsPCE(from, _msgSender(), displayFee)`:
+
+- `transferWithAuthorization`
+- `transferFromWithAuthorization`
+- `setInfinityApproveFlagWithAuthorization`
+- `claimVoucherWithAuthorization`
+
+No changes are made to `getMetaTransactionFee()` or `getMetaTransactionFeeWithBaseFee()` — the fee is still denominated and displayed in community token units.
+
+#### Storage
+
+No new storage variables are required. The existing swap rate parameters (`exchangeRate`, `getCurrentFactor()`, `lastModifiedFactor`) are reused for the fee conversion calculation.
+
+#### Events
+
+**PCECommunityToken — new event (replaces `MetaTransactionFeeCollected`):**
+
+```solidity
+event MetaTransactionFeeSwapped(
+    address indexed from,
+    address indexed relayer,
+    uint256 communityTokenFee,
+    uint256 pceFee
+);
+```
+
+**PCEToken — new event:**
+
+```solidity
+event FeeSwappedFromLocalToken(
+    address indexed fromToken,
+    address indexed relayer,
+    uint256 communityTokenAmount,
+    uint256 pceAmount
+);
+```
+
+The existing `MetaTransactionFeeCollected` event is no longer emitted.
+
+#### Fee Swap Algorithm
+
+When `_collectFeeAsPCE(from, relayer, displayFee)` is called:
+
+1. Convert `displayFee` to raw amount: `rawFee = displayBalanceToRawBalance(displayFee)`
+2. Burn community tokens from `from`: `_burn(from, rawFee)`
+3. Call `PCEToken(pceAddress).swapFeeFromLocalToken(address(this), relayer, displayFee)`
+
+When `PCEToken.swapFeeFromLocalToken(fromToken, relayer, communityTokenDisplayAmount)` is called:
+
+1. Verify `msg.sender == fromToken` and `localTokens[fromToken].isExists`
+2. Calculate PCE amount using the same formula as `swapFromLocalToken`:
+   ```
+   pceAmount = communityTokenDisplayAmount
+               × INITIAL_FACTOR / exchangeRate
+               × lastModifiedFactor / target.getCurrentFactor()
+   ```
+3. Transfer PCE to relayer: `_transfer(address(this), relayer, pceAmount)`
+4. **Do NOT** call `target.recordSwapToPCE()` — fee swaps are exempt from daily limits
+5. Emit `FeeSwappedFromLocalToken(fromToken, relayer, communityTokenDisplayAmount, pceAmount)`
+
+#### Special Case: Voucher Claims
+
+In `claimVoucherWithAuthorization`, the fee source is `address(this)` (the contract itself), not an end user. The same `_collectFeeAsPCE(address(this), relayer, displayFee)` call applies — community tokens held by the contract are burned and PCE is sent to the relayer.
+
+### Rationale
+
+**Why auto-swap instead of letting relayers swap manually?**
+Relayers operate infrastructure that serves all communities. Requiring them to manage and swap dozens of community token types creates unnecessary operational overhead. Auto-swap reduces this to zero by giving relayers exactly what they need: PCE.
+
+**Why exempt from daily swap limits?**
+Daily swap limits exist to prevent rapid economic destabilization from large speculative swaps. Meta-transaction fees are fundamentally different: they are small, predictable amounts driven by gas costs. Subjecting them to swap limits would cause meta-transaction failures when limits are exhausted, degrading user experience for all community members. The fee amounts are too small to pose any destabilization risk.
+
+**Why burn-and-transfer instead of transfer-and-swap?**
+Burning community tokens in the fee payer's context and transferring PCE from the PCEToken contract mirrors the existing `swapFromLocalToken` mechanic. This maintains consistency in how community token supply and PCE reserves interact.
+
+**Why replace `MetaTransactionFeeCollected` with a new event?**
+The semantics of the fee collection have changed: the relayer now receives PCE, not community tokens. A new event with explicit `pceFee` field provides accurate information for indexers and avoids misinterpretation of legacy event data.
+
+### Backwards Compatibility
+
+**Breaking changes:**
+
+- **Relayer fee denomination**: Relayers now receive PCE instead of community tokens. Relayer software MUST be updated to expect PCE balance increases rather than community token balance increases.
+- **Event change**: `MetaTransactionFeeCollected` is replaced by `MetaTransactionFeeSwapped`. Off-chain indexers and analytics that consume this event MUST be updated.
+
+**Non-breaking:**
+
+- `getMetaTransactionFee()` and `getMetaTransactionFeeWithBaseFee()` return values are unchanged (community token display units). Client-side fee estimation requires no changes.
+- User experience is unchanged — users still pay the same fee amount in community tokens.
+- No storage layout changes.
+
+### Test Cases
+
+All examples use `INITIAL_FACTOR = 10^18`.
+
+**Case 1: Standard fee swap**
+- Community token: exchangeRate = `2e18`, getCurrentFactor = `1e18`
+- PCEToken: lastModifiedFactor = `1e18`
+- Meta-transaction fee: `0.002` community tokens (displayFee)
+- PCE calculation: `0.002 × 1e18 / 2e18 × 1e18 / 1e18 = 0.001` PCE
+- Result: `0.002` community tokens burned from user, `0.001` PCE transferred to relayer
+- Daily swap counters: unchanged
+
+**Case 2: Fee swap with demurrage factors**
+- Community token: exchangeRate = `2e18`, getCurrentFactor = `0.99e18` (1% demurrage applied)
+- PCEToken: lastModifiedFactor = `0.98e18` (2% demurrage applied)
+- Meta-transaction fee: `0.002` community tokens (displayFee)
+- PCE calculation: `0.002 × 1e18 / 2e18 × 0.98e18 / 0.99e18 = 0.000990909...` PCE
+- Result: community tokens burned, PCE transferred with factor adjustment
+
+**Case 3: Fee swap does not affect daily limits**
+- Daily global swap limit: `1000` community tokens, already used: `1000` (exhausted)
+- Daily individual swap limit: `100` community tokens, already used: `100` (exhausted)
+- Meta-transaction fee: `0.002` community tokens
+- Result: Fee swap succeeds. Regular `swapFromLocalToken` would revert with "Exceeds daily swap limit", but fee swap bypasses limit checks entirely.
+
+**Case 4: Voucher claim fee swap**
+- Community token contract holds `10` community tokens (voucher balance)
+- Claimer calls `claimVoucherWithAuthorization`
+- Fee: `0.002` community tokens
+- Result: `0.002` community tokens burned from contract balance, equivalent PCE sent to relayer. Claimer receives remaining voucher amount minus fee.
+
+**Case 5: Insufficient PCE reserves**
+- PCEToken contract holds `0` PCE (all reserves depleted)
+- Meta-transaction fee swap attempts to transfer PCE to relayer
+- Result: Transaction reverts. The meta-transaction cannot be executed.
+
+### Security Considerations
+
+**Swap limit bypass is restricted to fee amounts**: The `swapFeeFromLocalToken` function can only be called by registered community token contracts (`msg.sender == fromToken`). The community token contracts only call this function during fee collection in `*WithAuthorization` functions, where the fee amount is deterministically calculated from gas parameters set by the contract owner. An attacker cannot inflate the fee amount to exploit the limit bypass.
+
+**PCE reserve depletion**: Fee swaps draw from the same PCE reserves as regular swaps. In extreme scenarios with very high meta-transaction volume across many communities, cumulative fee swaps could deplete PCE reserves faster than expected. However, individual fee amounts are negligible compared to regular swap volumes (typically < 0.01 PCE per transaction). Implementations SHOULD monitor PCE reserve levels.
+
+**Reentrancy**: `_collectFeeAsPCE` burns tokens (state change) before making an external call to `PCEToken.swapFeeFromLocalToken`. The PCEToken function performs a `_transfer` (state change). This follows the checks-effects-interactions pattern within each contract. Implementations SHOULD use a reentrancy guard on `swapFeeFromLocalToken` as defense-in-depth.
+
+**Rounding**: The fee undergoes two conversions: PCE → community token (in `getMetaTransactionFee`) → PCE (in `swapFeeFromLocalToken`). Due to integer division, the relayer may receive slightly less PCE than the theoretical gas cost. The rounding error is bounded by 1 wei per conversion step and is negligible in practice.
+
+**Atomicity**: The burn and PCE transfer occur in the same transaction. If the PCE transfer fails (e.g., insufficient reserves), the entire meta-transaction reverts. This prevents a state where community tokens are burned but no PCE is received.
+
+### Notes
+
+- **Scope of impact**: Requires upgrades to both PCEToken and PCECommunityToken contracts
+- **Interaction with PIP-2**: If PIP-2 (Community Treasury Wallet) is implemented, fee swaps reduce the PCEToken contract's PCE balance but do not modify `depositedPCEToken` for the community. This is consistent with how regular `swapFromLocalToken` operates — `depositedPCEToken` tracks capital operations only, not swap activity.
+- **Out of scope**: Relayer fee margin configuration (e.g., markup for profit) is not addressed. Native token conversion (PCE → MATIC/POL) for actual gas payment remains the relayer's responsibility.
+- **Dependencies**: None (builds on existing meta-transaction and swap infrastructure)


### PR DESCRIPTION
## Summary

- Add PIP-13: Meta-Transaction Fee Auto-Swap to PCE
- **PIP full text**: [PIPs/pip-13.md](https://github.com/peacecoin-protocol/PIPs/blob/pip-13/PIPs/pip-13.md)
- Implementation: https://github.com/peacecoin-protocol/core/pull/31
- Tally Proposal: https://www.tally.xyz/gov/pce-dao/draft/2811459409178264786

## Abstract

This proposal changes meta-transaction fee settlement from direct community token transfer to automatic PCE conversion. When a relayer executes a meta-transaction, the fee collected from the user in community tokens is burned and the equivalent amount of PCE is transferred to the relayer. This swap is exempt from daily swap limits.

### Key Points

- **Auto-Swap**: Meta-transaction fees are burned as community tokens and equivalent PCE is transferred to the relayer via `swapFeeFromLocalToken`
- **Swap Limit Exemption**: Fee swaps bypass both daily global and individual swap limits, preventing meta-transaction failures when limits are exhausted
- **Relayer Simplification**: Relayers receive PCE directly instead of accumulating various community tokens across communities
- **Scope**: Requires upgrades to both PCEToken and PCECommunityToken contracts

### Changes in latest update

- **Fix**: Notes section corrected — fee swaps DO decrease `depositedPCEToken`, consistent with regular `swapFromLocalToken` behavior
- **Fix**: PIP-12 reference updated (was "PIP-2")
- **Fix**: `MATIC/POL` → `POL` (Polygon native token rebrand)

---

<details><summary>日本語版 PIP 全文</summary>

```
---
pip: 13
title: Meta-Transaction Fee Auto-Swap to PCE
proposer: CHIBA Masahiro (@nihen)
status: Draft
type: Core
created: 2026-03-13
requires: []
replaces: []
---
```

## PIP-13: Meta-Transaction Fee Auto-Swap to PCE（メタトランザクション手数料のPCE自動変換）

### Abstract（概要）

メタトランザクション手数料の決済方式を、コミュニティトークンの直接転送からPCEへの自動変換に変更する。リレイヤーがメタトランザクションを実行する際、ユーザーから徴収したコミュニティトークン手数料をburnし、同等のPCEをリレイヤーに転送する。このスワップは日次スワップ制限の対象外とする。

### Motivation（動機）

現在の設計では、メタトランザクション手数料はトランザクション対象のコミュニティトークンで徴収され、リレイヤー（`_msgSender()`）に直接転送される。これには2つの問題がある：

1. **リレイヤーのトークン断片化**: リレイヤーは複数のコミュニティにわたって多種多様なコミュニティトークンを蓄積する。これらのトークンは直接的な用途が限られている — リレイヤーがガスコストを賄うために必要なのはPCE（またはネイティブトークン）であり、コミュニティトークンのポートフォリオではない。

2. **レート制限付きの手動スワップ負担**: 蓄積したコミュニティトークンをPCEに変換するには、リレイヤーはトークン種別ごとに`swapFromLocalToken`を呼び出す必要があり、日次グローバルリミットおよび個人リミットの制約を受ける。活動が活発な時期には、リミット超過により手数料をスワップできない状況が発生しうる。

本提案は、手数料徴収時にPCEへの自動変換を行い、スワップ制限を免除することで両方の問題を解決する。

### Specification（仕様）

#### Interface（インターフェース）

**PCEToken — 新規関数:**

```solidity
/// @notice コミュニティトークン手数料をPCEにスワップし、リレイヤーに転送する。
///         コミュニティトークンコントラクト自身からのみ呼び出し可能。
///         日次スワップ制限の対象外。
/// @param fromToken コミュニティトークンのコントラクトアドレス（msg.senderと一致する必要がある）
/// @param relayer PCEを受け取るリレイヤーアドレス
/// @param communityTokenDisplayAmount コミュニティトークン表示単位での手数料額
/// @return pceAmount リレイヤーに転送されたPCE量
function swapFeeFromLocalToken(
    address fromToken,
    address relayer,
    uint256 communityTokenDisplayAmount
) external returns (uint256 pceAmount);
```

**PCECommunityToken — 新規内部関数:**

```solidity
/// @notice 手数料支払者からコミュニティトークンをburnし、同等のPCEをリレイヤーに送付する。
/// @param from 手数料を支払うアドレス（トークン保有者）
/// @param relayer PCEを受け取るリレイヤーアドレス
/// @param displayFee コミュニティトークン表示単位での手数料額
function _collectFeeAsPCE(
    address from,
    address relayer,
    uint256 displayFee
) internal returns (uint256 pceAmount);
```

**PCECommunityToken — 変更される関数:**

以下の関数において、`super._transfer(from, _msgSender(), rawFee)` を `_collectFeeAsPCE(from, _msgSender(), displayFee)` に置き換える：

- `transferWithAuthorization`
- `transferFromWithAuthorization`
- `setInfinityApproveFlagWithAuthorization`
- `claimVoucherWithAuthorization`

`getMetaTransactionFee()` および `getMetaTransactionFeeWithBaseFee()` に変更はない — 手数料は引き続きコミュニティトークン単位で表示・計算される。

#### Storage（ストレージ）

新規ストレージ変数は不要。既存のスワップレートパラメータ（`exchangeRate`、`getCurrentFactor()`、`lastModifiedFactor`）を手数料変換の計算に再利用する。

#### Events（イベント）

**PCECommunityToken — 新規イベント（`MetaTransactionFeeCollected`を置き換え）:**

```solidity
event MetaTransactionFeeSwapped(
    address indexed from,
    address indexed relayer,
    uint256 communityTokenFee,
    uint256 pceFee
);
```

**PCEToken — 新規イベント:**

```solidity
event FeeSwappedFromLocalToken(
    address indexed fromToken,
    address indexed relayer,
    uint256 communityTokenAmount,
    uint256 pceAmount
);
```

既存の`MetaTransactionFeeCollected`イベントは発行されなくなる。

#### Fee Swap Algorithm（手数料スワップアルゴリズム）

`_collectFeeAsPCE(from, relayer, displayFee)` が呼ばれた場合：

1. `displayFee`をraw amountに変換: `rawFee = displayBalanceToRawBalance(displayFee)`
2. `from`からコミュニティトークンをburn: `_burn(from, rawFee)`
3. `PCEToken(pceAddress).swapFeeFromLocalToken(address(this), relayer, displayFee)` を呼び出す

`PCEToken.swapFeeFromLocalToken(fromToken, relayer, communityTokenDisplayAmount)` が呼ばれた場合：

1. `msg.sender == fromToken` かつ `localTokens[fromToken].isExists` を検証
2. `swapFromLocalToken`と同じ計算式でPCE量を算出:
   ```
   pceAmount = communityTokenDisplayAmount
               × INITIAL_FACTOR / exchangeRate
               × lastModifiedFactor / target.getCurrentFactor()
   ```
3. PCEをリレイヤーに転送: `_transfer(address(this), relayer, pceAmount)`
4. `target.recordSwapToPCE()` を**呼び出さない** — 手数料スワップは日次制限の対象外
5. `FeeSwappedFromLocalToken(fromToken, relayer, communityTokenDisplayAmount, pceAmount)` をemit

#### Special Case: Voucher Claims（特殊ケース：バウチャー請求）

`claimVoucherWithAuthorization`では、手数料の出所は`address(this)`（コントラクト自身）であり、エンドユーザーではない。同じ`_collectFeeAsPCE(address(this), relayer, displayFee)`呼び出しが適用される — コントラクトが保有するコミュニティトークンがburnされ、PCEがリレイヤーに送付される。

### Rationale（設計根拠）

**なぜリレイヤーに手動スワップさせるのではなく自動スワップにするのか？**
リレイヤーは全コミュニティにサービスを提供するインフラである。数十種類のコミュニティトークンの管理とスワップを要求することは不要な運用負荷を生む。自動スワップにより、リレイヤーが必要とするもの（PCE）を直接受け取れるようになり、運用負荷はゼロになる。

**なぜ日次スワップ制限から免除するのか？**
日次スワップ制限は、大規模な投機的スワップによる急激な経済的不安定化を防ぐために存在する。メタトランザクション手数料は本質的に異なる：ガスコストに基づく少額かつ予測可能な金額である。スワップ制限の対象にすると、リミット超過時にメタトランザクションが失敗し、全コミュニティメンバーのユーザー体験を低下させる。手数料の金額は経済的不安定化リスクを生じるには小さすぎる。

**なぜtransfer-and-swapではなくburn-and-transferなのか？**
手数料支払者のコンテキストでコミュニティトークンをburnし、PCETokenコントラクトからPCEを転送する方式は、既存の`swapFromLocalToken`のメカニズムと一致する。コミュニティトークン供給量とPCEリザーブの相互作用における一貫性を維持できる。

**なぜ`MetaTransactionFeeCollected`を新しいイベントに置き換えるのか？**
手数料徴収のセマンティクスが変化した：リレイヤーはコミュニティトークンではなくPCEを受け取るようになった。明示的な`pceFee`フィールドを持つ新しいイベントにより、インデクサーに正確な情報を提供し、レガシーイベントデータの誤解を防ぐ。

### Backwards Compatibility（後方互換性）

**破壊的変更:**

- **リレイヤー手数料の通貨単位**: リレイヤーはコミュニティトークンではなくPCEを受け取るようになる。リレイヤーソフトウェアは、コミュニティトークンの残高増加ではなくPCE残高の増加を期待するように更新する必要がある(MUST)。
- **イベント変更**: `MetaTransactionFeeCollected`は`MetaTransactionFeeSwapped`に置き換わる。このイベントを消費するオフチェーンインデクサーおよび分析ツールは更新する必要がある(MUST)。

**非破壊的:**

- `getMetaTransactionFee()` および `getMetaTransactionFeeWithBaseFee()` の戻り値は変更なし（コミュニティトークン表示単位）。クライアント側の手数料見積もりに変更は不要。
- ユーザー体験は変更なし — ユーザーは同じ手数料額をコミュニティトークンで支払う。
- ストレージレイアウトの変更なし。

### Test Cases（テストケース）

すべての例で`INITIAL_FACTOR = 10^18`を使用。

**ケース1: 標準的な手数料スワップ**
- コミュニティトークン: exchangeRate = `2e18`, getCurrentFactor = `1e18`
- PCEToken: lastModifiedFactor = `1e18`
- メタトランザクション手数料: `0.002` コミュニティトークン (displayFee)
- PCE計算: `0.002 × 1e18 / 2e18 × 1e18 / 1e18 = 0.001` PCE
- 結果: ユーザーから`0.002`コミュニティトークンがburn、リレイヤーに`0.001` PCEが転送
- 日次スワップカウンター: 変更なし

**ケース2: デマレージファクター適用時の手数料スワップ**
- コミュニティトークン: exchangeRate = `2e18`, getCurrentFactor = `0.99e18`（1%デマレージ適用）
- PCEToken: lastModifiedFactor = `0.98e18`（2%デマレージ適用）
- メタトランザクション手数料: `0.002` コミュニティトークン (displayFee)
- PCE計算: `0.002 × 1e18 / 2e18 × 0.98e18 / 0.99e18 = 0.000990909...` PCE
- 結果: コミュニティトークンがburn、ファクター調整後のPCEが転送

**ケース3: 手数料スワップは日次制限に影響しない**
- 日次グローバルスワップ制限: `1000` コミュニティトークン、使用済み: `1000`（枯渇）
- 日次個人スワップ制限: `100` コミュニティトークン、使用済み: `100`（枯渇）
- メタトランザクション手数料: `0.002` コミュニティトークン
- 結果: 手数料スワップは成功する。通常の`swapFromLocalToken`は"Exceeds daily swap limit"でrevertするが、手数料スワップはリミットチェックを完全にバイパスする。

**ケース4: バウチャー請求の手数料スワップ**
- コミュニティトークンコントラクトが`10`コミュニティトークンを保有（バウチャー残高）
- 請求者が`claimVoucherWithAuthorization`を呼び出す
- 手数料: `0.002` コミュニティトークン
- 結果: コントラクト残高から`0.002`コミュニティトークンがburn、同等のPCEがリレイヤーに送付。請求者は手数料を差し引いた残りのバウチャー額を受け取る。

**ケース5: PCEリザーブ不足**
- PCETokenコントラクトが`0` PCEを保有（全リザーブ枯渇）
- 手数料スワップがリレイヤーへのPCE転送を試行
- 結果: トランザクションがrevert。メタトランザクションは実行できない。

### Security Considerations（セキュリティ考慮事項）

**スワップ制限バイパスは手数料額に限定**: `swapFeeFromLocalToken`関数は登録済みコミュニティトークンコントラクトからのみ呼び出し可能（`msg.sender == fromToken`）。コミュニティトークンコントラクトがこの関数を呼び出すのは`*WithAuthorization`関数での手数料徴収時のみであり、手数料額はコントラクトオーナーが設定したガスパラメータから決定論的に計算される。攻撃者がリミットバイパスを悪用するために手数料額を膨らませることはできない。

**PCEリザーブの枯渇**: 手数料スワップは通常のスワップと同じPCEリザーブから引き出す。多数のコミュニティにわたって非常に高いメタトランザクション量が発生する極端なシナリオでは、累積的な手数料スワップがPCEリザーブを予想以上に早く減少させる可能性がある。ただし、個々の手数料額は通常のスワップ量と比較して無視できる程度（通常、トランザクションあたり0.01 PCE未満）。実装はPCEリザーブ水準を監視すべきである(SHOULD)。

**リエントランシー**: `_collectFeeAsPCE`はトークンをburn（状態変更）してから`PCEToken.swapFeeFromLocalToken`への外部呼び出しを行う。PCEToken関数は`_transfer`（状態変更）を実行する。これは各コントラクト内でchecks-effects-interactionsパターンに従っている。多層防御として`swapFeeFromLocalToken`にリエントランシーガードを使用すべきである(SHOULD)。

**丸め誤差**: 手数料は2回の変換を経る：PCE → コミュニティトークン（`getMetaTransactionFee`内）→ PCE（`swapFeeFromLocalToken`内）。整数除算により、リレイヤーが受け取るPCEは理論的なガスコストよりわずかに少なくなりうる。丸め誤差は変換ステップごとに1 weiに制限され、実用上は無視できる。

**原子性**: burnとPCE転送は同一トランザクション内で発生する。PCE転送が失敗した場合（例：リザーブ不足）、メタトランザクション全体がrevertする。コミュニティトークンがburnされたがPCEが受け取れないという状態を防止する。

### Notes（備考）

- **影響範囲**: PCETokenとPCECommunityTokenの両方のコントラクトのアップグレードが必要
- **PIP-12との相互作用**: PIP-12（Community Treasury Wallet and Capital Operations）が実装されている場合、手数料スワップはPCETokenコントラクトのPCE残高と当該コミュニティの`depositedPCEToken`の両方を減少させる。これは通常の`swapFromLocalToken`の動作と一致する — 両関数ともPCEがコントラクトから出る際に`depositedPCEToken`を減少させる。
- **スコープ外**: リレイヤーの手数料マージン設定（例：利益のための上乗せ）は扱わない。実際のガス支払いのためのネイティブトークン変換（PCE → POL）はリレイヤーの責任のまま。
- **依存関係**: なし（既存のメタトランザクションおよびスワップインフラストラクチャの上に構築）

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

