### PR TITLE
PIP-15: Message Count and Attachment Flags for Arigato Creation in Transfers

### DIFF
--- a/PIPs/pip-15.md
+++ b/PIPs/pip-15.md
@@ -1,6 +1,6 @@
 ---
 pip: 15
-title: "Message Count Parameter for Arigato Creation in Transfers"
+title: "Message Count and Attachment Flags for Arigato Creation in Transfers"
 proposer: "CHIBA Masahiro (@nihen)"
 status: "Draft"
 type: "Core"
@@ -15,41 +15,47 @@ The Arigato Creation algorithm in `PCECommunityToken` already accepts a `message
 
 This means the Arigato Creation incentive curve cannot differentiate between a bare token transfer and a transfer accompanied by a meaningful message (e.g., a gratitude note in a community app). Unlocking this parameter allows front-end applications to pass the actual message count, enabling the protocol to reward richer social interactions as originally designed.
 
+Additionally, modern community applications allow users to attach voice messages or images to gratitude transfers. These rich media attachments represent a higher level of social engagement. By introducing `hasVoiceAttachment` and `hasImageAttachment` flags and reducing the usage-rate deviation penalty for transfers with attachments, the protocol incentivizes more meaningful interactions.
+
 ## 2. Specification / Details
 
 ### New Functions
 
-Four new public functions are added to `PCECommunityToken`, each mirroring an existing transfer function but accepting an additional `messageCount` parameter:
+Four new public functions are added to `PCECommunityToken`, each mirroring an existing transfer function but accepting additional `messageCount`, `hasVoiceAttachment`, and `hasImageAttachment` parameters:
 
-#### 2.1 `transferWithMessageCount`
+#### 2.1 `transferWithMetadata`
 
 ```solidity
-function transferWithMessageCount(
+function transferWithMetadata(
     address receiver,
     uint256 displayAmount,
-    uint256 messageCount
+    uint256 messageCount,
+    bool hasVoiceAttachment,
+    bool hasImageAttachment
 ) public returns (bool);
 ```
 
-Behaves identically to `transfer`, except `messageCount` is passed to `_mintArigatoCreation` instead of the hardcoded `1`.
+Behaves identically to `transfer`, except `messageCount` is passed to `_mintArigatoCreation` instead of the hardcoded `1`, and attachment flags are applied to reduce the deviation penalty.
 
-#### 2.2 `transferFromWithMessageCount`
+#### 2.2 `transferFromWithMetadata`
 
 ```solidity
-function transferFromWithMessageCount(
+function transferFromWithMetadata(
     address sender,
     address receiver,
     uint256 displayBalance,
-    uint256 messageCount
+    uint256 messageCount,
+    bool hasVoiceAttachment,
+    bool hasImageAttachment
 ) public returns (bool);
 ```
 
-Behaves identically to `transferFrom`, except `messageCount` is passed to `_mintArigatoCreation`.
+Behaves identically to `transferFrom`, except `messageCount` is passed to `_mintArigatoCreation` and attachment flags are applied.
 
-#### 2.3 `transferWithAuthorizationWithMessageCount`
+#### 2.3 `transferWithAuthorizationAndMetadata`
 
 ```solidity
-function transferWithAuthorizationWithMessageCount(
+function transferWithAuthorizationAndMetadata(
     address from,
     address to,
     uint256 displayAmount,
@@ -59,23 +65,26 @@ function transferWithAuthorizationWithMessageCount(
     uint8 v,
     bytes32 r,
     bytes32 s,
-    uint256 messageCount
+    uint256 messageCount,
+    bool hasVoiceAttachment,
+    bool hasImageAttachment
 ) public;
 ```
 
 Behaves identically to `transferWithAuthorization`, except:
 - `messageCount` is passed to `_mintArigatoCreation`.
-- A **new EIP-712 typehash** is used for signature verification that includes the `messageCount` field, preventing third parties from tampering with the value.
+- Attachment flags are applied to reduce the deviation penalty.
+- A **new EIP-712 typehash** is used for signature verification that includes all metadata fields, preventing third parties from tampering with the values.
 
 **EIP-712 Type:**
 ```
-TransferWithAuthorizationWithMessageCount(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount)
+TransferWithAuthorizationAndMetadata(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount,bool hasVoiceAttachment,bool hasImageAttachment)
 ```
 
-#### 2.4 `transferFromWithAuthorizationWithMessageCount`
+#### 2.4 `transferFromWithAuthorizationAndMetadata`
 
 ```solidity
-function transferFromWithAuthorizationWithMessageCount(
+function transferFromWithAuthorizationAndMetadata(
     address spender,
     address from,
     address to,
@@ -86,49 +95,112 @@ function transferFromWithAuthorizationWithMessageCount(
     uint8 v,
     bytes32 r,
     bytes32 s,
-    uint256 messageCount
+    uint256 messageCount,
+    bool hasVoiceAttachment,
+    bool hasImageAttachment
 ) public;
 ```
 
 Behaves identically to `transferFromWithAuthorization`, except:
 - `messageCount` is passed to `_mintArigatoCreation`.
-- A **new EIP-712 typehash** is used that includes the `messageCount` field.
+- Attachment flags are applied to reduce the deviation penalty.
+- A **new EIP-712 typehash** is used that includes all metadata fields.
 
 **EIP-712 Type:**
 ```
-TransferFromWithAuthorizationWithMessageCount(address spender,address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount)
+TransferFromWithAuthorizationAndMetadata(address spender,address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount,bool hasVoiceAttachment,bool hasImageAttachment)
 ```
+
+### Attachment Penalty Reduction
+
+Each attachment flag reduces the usage-rate deviation penalty (`changeMulBp`). The reduction rates are **configurable per community token** via setter functions, with the following protocol-wide defaults:
+
+```
+DEFAULT_VOICE_REDUCTION_BP = 1000   // 10%
+DEFAULT_IMAGE_REDUCTION_BP = 1000   // 10%
+```
+
+#### Per-Token Configuration
+
+Each `PCECommunityToken` stores its own reduction rates. If not explicitly set, the default values above are used.
+
+```solidity
+// Storage
+uint256 public voiceReductionBp;   // initialized to DEFAULT_VOICE_REDUCTION_BP
+uint256 public imageReductionBp;   // initialized to DEFAULT_IMAGE_REDUCTION_BP
+
+// Setter (owner only)
+function setAttachmentReductionBp(
+    uint256 _voiceReductionBp,
+    uint256 _imageReductionBp
+) external onlyOwner;
+```
+
+**Constraints:**
+- Each value must be in the range `[0, 5000]` (0% to 50%).
+- The sum `voiceReductionBp + imageReductionBp` must not exceed `5000` (50%), ensuring the penalty is never reduced by more than half.
+
+#### Penalty Reduction Formula
+
+```
+attachmentReductionBp = 0
+if hasVoiceAttachment: attachmentReductionBp += voiceReductionBp
+if hasImageAttachment: attachmentReductionBp += imageReductionBp
+
+effectiveChangeMulBp = changeMulBp × (BP_BASE - attachmentReductionBp) / BP_BASE
+
+increaseBp = maxIncreaseBp - (effectiveChangeMulBp × messageBp) / BP_BASE
+```
+
+#### Example with Default Values (10% each)
+
+| Attachments | Penalty Reduction | Effect |
+|-------------|-------------------|--------|
+| None | 0% | `effectiveChangeMulBp = changeMulBp` (unchanged) |
+| Voice only | 10% | `effectiveChangeMulBp = changeMulBp × 9000 / 10000` |
+| Image only | 10% | `effectiveChangeMulBp = changeMulBp × 9000 / 10000` |
+| Voice + Image | 20% | `effectiveChangeMulBp = changeMulBp × 8000 / 10000` |
+
+A transfer with both voice and image attachments has its deviation penalty reduced by 20%, resulting in a larger `increaseBp` and more Arigato Creation minted.
 
 ### Unchanged Behavior
 
-- Existing `transfer`, `transferFrom`, `transferWithAuthorization`, and `transferFromWithAuthorization` remain **unchanged** and continue to pass `1` to `_mintArigatoCreation`. No breaking changes.
-- The internal `_mintArigatoCreation` function is not modified.
+- Existing `transfer`, `transferFrom`, `transferWithAuthorization`, and `transferFromWithAuthorization` remain **unchanged** and continue to pass `1` to `_mintArigatoCreation` with no attachment reduction. No breaking changes.
 - `messageCount` is clamped by the existing `MAX_CHARACTER_LENGTH` constant (`10`) inside `_mintArigatoCreation` — values above 10 are treated as 10.
 
 ### New Events
 
 ```solidity
-event TransferWithMessageCount(
+event TransferWithMetadata(
     address indexed from,
     address indexed to,
     uint256 displayAmount,
-    uint256 messageCount
+    uint256 messageCount,
+    bool hasVoiceAttachment,
+    bool hasImageAttachment
+);
+
+event AttachmentReductionBpUpdated(
+    uint256 voiceReductionBp,
+    uint256 imageReductionBp
 );
 ```
 
-Emitted by all four new functions to allow indexers to track message-count-aware transfers.
+`TransferWithMetadata` is emitted by all four new functions to allow indexers to track metadata-aware transfers. `AttachmentReductionBpUpdated` is emitted when the owner changes the reduction rates.
 
 ## 3. Impact and Compatibility
 
 **Backwards Compatibility:** Fully backwards compatible. Existing functions are untouched. Existing callers (wallets, relayers) require no changes.
 
-**Storage:** No new storage variables. No storage layout changes.
+**Storage:** Two new `uint256` storage variables (`voiceReductionBp`, `imageReductionBp`) are added per community token. These are initialized to the default values during deployment/upgrade.
 
-**Contract Size:** Four new functions increase bytecode. Given the existing contract is close to the EVM size limit, this should be monitored during implementation.
+**Contract Size:** Four new functions and a setter increase bytecode. Given the existing contract is close to the EVM size limit, this should be monitored during implementation.
 
-**Front-end Impact:** Applications that wish to leverage message-count-aware Arigato Creation must call the new functions. Standard ERC-20 `transfer`/`transferFrom` calls continue to work with `messageCount=1`.
+**Front-end Impact:** Applications that wish to leverage metadata-aware Arigato Creation must call the new functions. Standard ERC-20 `transfer`/`transferFrom` calls continue to work with `messageCount=1` and no attachment reduction.
 
 **Relayer Impact:** Relayers supporting the new `WithAuthorization` variants must construct signatures using the new EIP-712 typehashes.
+
+**Governance Impact:** Community token owners can tune penalty reduction rates to match their community's engagement patterns without requiring a contract upgrade.
 
 ## 4. Rationale and Alternatives
 
@@ -138,14 +210,25 @@ Changing the signature of `transfer(address, uint256)` would break ERC-20 compat
 **Why not use a storage-based setter (e.g., `setMessageCount` then `transfer`)?**
 A two-step pattern is vulnerable to front-running: an attacker could call `transfer` between the user's `setMessageCount` and `transfer` calls, consuming the stored value. It also requires two transactions in the non-meta-transaction case. A single-function approach is atomic and simpler.
 
-**Why include `messageCount` in the EIP-712 signature?**
-Without it, a relayer or front-runner could alter the `messageCount` value after the user signs the authorization. Including it in the signed data ensures only the signer can determine the message count.
+**Why include metadata fields in the EIP-712 signature?**
+Without it, a relayer or front-runner could alter the `messageCount` or attachment flags after the user signs the authorization. Including them in the signed data ensures only the signer can determine the values.
+
+**Why boolean flags instead of an attachment count or enum?**
+Boolean flags are self-documenting in ABI, easy for front-end developers to use, and EVM-efficient (packed into a single slot). They clearly convey presence/absence of each attachment type.
+
+**Why configurable penalty reduction rates per community token?**
+Different communities have different engagement patterns. A community focused on visual art may want a higher image attachment reduction, while a voice-chat-centric community may want to weight voice attachments more heavily. Per-token configuration allows each community to tune incentives without protocol-level changes. The protocol-wide defaults (10% each) provide a sensible starting point.
+
+**Why cap the total reduction at 50%?**
+The penalty curve is a core mechanism for maintaining healthy usage-rate distribution. Allowing reductions beyond 50% would risk making the penalty ineffective, potentially enabling gaming of the Arigato Creation algorithm.
 
 ## Notes (Optional)
 
-- Related implementation: https://github.com/peacecoin-protocol/core/pull/TBD
+- Related implementation: https://github.com/peacecoin-protocol/core/pull/34
 - Requires: None
 - The `messageCount` parameter represents the number of message characters associated with the transfer, as defined by the existing Arigato Creation algorithm. Values of `0` are treated as `1` by `_mintArigatoCreation`.
+- `hasVoiceAttachment` and `hasImageAttachment` each apply their respective configurable penalty reduction. They stack additively (voice + image = sum of both reduction rates).
+- Community token owners can call `setAttachmentReductionBp` at any time to adjust rates. Setting both to `0` effectively disables the attachment reduction feature for that token.
 
 ## 5. Copyright and License
 

--- a/PIPs/pip-15.md
+++ b/PIPs/pip-15.md
@@ -1,0 +1,152 @@
+---
+pip: 15
+title: "Message Count Parameter for Arigato Creation in Transfers"
+proposer: "CHIBA Masahiro (@nihen)"
+status: "Draft"
+type: "Core"
+created: "2026-03-25"
+requires: []
+replaces: []
+---
+
+## 1. Motivation
+
+The Arigato Creation algorithm in `PCECommunityToken` already accepts a `messageCharacters` parameter that influences the mint calculation — specifically, the penalty curve applied when the sender's usage rate deviates from the optimal rate. However, all current transfer functions (`transfer`, `transferFrom`, `transferWithAuthorization`, `transferFromWithAuthorization`) hardcode this value to `1`.
+
+This means the Arigato Creation incentive curve cannot differentiate between a bare token transfer and a transfer accompanied by a meaningful message (e.g., a gratitude note in a community app). Unlocking this parameter allows front-end applications to pass the actual message count, enabling the protocol to reward richer social interactions as originally designed.
+
+## 2. Specification / Details
+
+### New Functions
+
+Four new public functions are added to `PCECommunityToken`, each mirroring an existing transfer function but accepting an additional `messageCount` parameter:
+
+#### 2.1 `transferWithMessageCount`
+
+```solidity
+function transferWithMessageCount(
+    address receiver,
+    uint256 displayAmount,
+    uint256 messageCount
+) public returns (bool);
+```
+
+Behaves identically to `transfer`, except `messageCount` is passed to `_mintArigatoCreation` instead of the hardcoded `1`.
+
+#### 2.2 `transferFromWithMessageCount`
+
+```solidity
+function transferFromWithMessageCount(
+    address sender,
+    address receiver,
+    uint256 displayBalance,
+    uint256 messageCount
+) public returns (bool);
+```
+
+Behaves identically to `transferFrom`, except `messageCount` is passed to `_mintArigatoCreation`.
+
+#### 2.3 `transferWithAuthorizationWithMessageCount`
+
+```solidity
+function transferWithAuthorizationWithMessageCount(
+    address from,
+    address to,
+    uint256 displayAmount,
+    uint256 validAfter,
+    uint256 validBefore,
+    bytes32 nonce,
+    uint8 v,
+    bytes32 r,
+    bytes32 s,
+    uint256 messageCount
+) public;
+```
+
+Behaves identically to `transferWithAuthorization`, except:
+- `messageCount` is passed to `_mintArigatoCreation`.
+- A **new EIP-712 typehash** is used for signature verification that includes the `messageCount` field, preventing third parties from tampering with the value.
+
+**EIP-712 Type:**
+```
+TransferWithAuthorizationWithMessageCount(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount)
+```
+
+#### 2.4 `transferFromWithAuthorizationWithMessageCount`
+
+```solidity
+function transferFromWithAuthorizationWithMessageCount(
+    address spender,
+    address from,
+    address to,
+    uint256 displayAmount,
+    uint256 validAfter,
+    uint256 validBefore,
+    bytes32 nonce,
+    uint8 v,
+    bytes32 r,
+    bytes32 s,
+    uint256 messageCount
+) public;
+```
+
+Behaves identically to `transferFromWithAuthorization`, except:
+- `messageCount` is passed to `_mintArigatoCreation`.
+- A **new EIP-712 typehash** is used that includes the `messageCount` field.
+
+**EIP-712 Type:**
+```
+TransferFromWithAuthorizationWithMessageCount(address spender,address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount)
+```
+
+### Unchanged Behavior
+
+- Existing `transfer`, `transferFrom`, `transferWithAuthorization`, and `transferFromWithAuthorization` remain **unchanged** and continue to pass `1` to `_mintArigatoCreation`. No breaking changes.
+- The internal `_mintArigatoCreation` function is not modified.
+- `messageCount` is clamped by the existing `MAX_CHARACTER_LENGTH` constant (`10`) inside `_mintArigatoCreation` — values above 10 are treated as 10.
+
+### New Events
+
+```solidity
+event TransferWithMessageCount(
+    address indexed from,
+    address indexed to,
+    uint256 displayAmount,
+    uint256 messageCount
+);
+```
+
+Emitted by all four new functions to allow indexers to track message-count-aware transfers.
+
+## 3. Impact and Compatibility
+
+**Backwards Compatibility:** Fully backwards compatible. Existing functions are untouched. Existing callers (wallets, relayers) require no changes.
+
+**Storage:** No new storage variables. No storage layout changes.
+
+**Contract Size:** Four new functions increase bytecode. Given the existing contract is close to the EVM size limit, this should be monitored during implementation.
+
+**Front-end Impact:** Applications that wish to leverage message-count-aware Arigato Creation must call the new functions. Standard ERC-20 `transfer`/`transferFrom` calls continue to work with `messageCount=1`.
+
+**Relayer Impact:** Relayers supporting the new `WithAuthorization` variants must construct signatures using the new EIP-712 typehashes.
+
+## 4. Rationale and Alternatives
+
+**Why new functions instead of modifying existing ones?**
+Changing the signature of `transfer(address, uint256)` would break ERC-20 compatibility. Changing `transferWithAuthorization` would break existing relayer integrations and invalidate any pre-signed authorizations. New functions preserve full backwards compatibility.
+
+**Why not use a storage-based setter (e.g., `setMessageCount` then `transfer`)?**
+A two-step pattern is vulnerable to front-running: an attacker could call `transfer` between the user's `setMessageCount` and `transfer` calls, consuming the stored value. It also requires two transactions in the non-meta-transaction case. A single-function approach is atomic and simpler.
+
+**Why include `messageCount` in the EIP-712 signature?**
+Without it, a relayer or front-runner could alter the `messageCount` value after the user signs the authorization. Including it in the signed data ensures only the signer can determine the message count.
+
+## Notes (Optional)
+
+- Related implementation: https://github.com/peacecoin-protocol/core/pull/TBD
+- Requires: None
+- The `messageCount` parameter represents the number of message characters associated with the transfer, as defined by the existing Arigato Creation algorithm. Values of `0` are treated as `1` by `_mintArigatoCreation`.
+
+## 5. Copyright and License
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

- Add PIP-15: Message Count and Attachment Flags for Arigato Creation in Transfers
- **PIP full text**: [PIPs/pip-15.md](https://github.com/peacecoin-protocol/PIPs/blob/pip-15/PIPs/pip-15.md)
- Implementation: https://github.com/peacecoin-protocol/core/pull/34

## Abstract

This proposal adds new transfer functions (`transferWithMetadata`, `transferFromWithMetadata`, `transferWithAuthorizationAndMetadata`, `transferFromWithAuthorizationAndMetadata`) to `PCECommunityToken` that accept `messageCount`, `hasVoiceAttachment`, and `hasImageAttachment` parameters. These parameters are passed to the existing `_mintArigatoCreation` algorithm, enabling front-end applications to leverage the full Arigato Creation incentive curve based on actual message activity and rich media attachments.

### Key Points

- **New Functions**: Four new transfer variants that accept `messageCount`, `hasVoiceAttachment`, and `hasImageAttachment`
- **Configurable Penalty Reduction**: Each attachment flag reduces the usage-rate deviation penalty by a configurable amount per community token (default: 10% each)
- **Per-Token Configuration**: `setAttachmentReductionBp(voiceReductionBp, imageReductionBp)` allows community token owners to tune rates (capped at 50% total)
- **Backwards Compatible**: Existing `transfer`, `transferFrom`, `transferWithAuthorization`, and `transferFromWithAuthorization` are unchanged
- **Signature Safety**: Authorization variants use new EIP-712 typehashes that include all metadata fields

### Penalty Reduction (Configurable per Community Token)

```
// Storage (per community token)
voiceReductionBp  // default: 1000 (10%)
imageReductionBp  // default: 1000 (10%)

// Formula
attachmentReductionBp = 0
if hasVoiceAttachment: attachmentReductionBp += voiceReductionBp
if hasImageAttachment: attachmentReductionBp += imageReductionBp

effectiveChangeMulBp = changeMulBp × (BP_BASE - attachmentReductionBp) / BP_BASE
increaseBp = maxIncreaseBp - (effectiveChangeMulBp × messageBp) / BP_BASE
```

| Attachments | Default Penalty Reduction |
|-------------|--------------------------|
| None | 0% |
| Voice only | 10% |
| Image only | 10% |
| Voice + Image | 20% |

Community token owners can adjust these rates via `setAttachmentReductionBp` to match their community's engagement patterns.

---

<details>
<summary>日本語版 PIP 全文</summary>

## PIP-15: ARIGATO CREATIONにおけるメッセージカウント・添付フラグパラメータの送金関数への追加

### 概要

`PCECommunityToken` の送金関数に `messageCount`、`hasVoiceAttachment`、`hasImageAttachment` パラメータを受け取る新しいバリアントを追加する。現在ハードコードされている値の代わりに、フロントエンドアプリケーションが実際のメッセージ数と添付メディア情報を渡せるようにする。

### 動機

ARIGATO CREATIONアルゴリズムは既に `messageCharacters` パラメータを受け取り、使用率の最適レートからの逸脱に対するペナルティカーブに影響を与える設計になっている。しかし、現在の全送金関数ではこの値が `1` にハードコードされている。

さらに、現代のコミュニティアプリケーションでは、感謝の送金に音声メッセージや画像を添付できる。これらのリッチメディア添付はより高いレベルの社会的エンゲージメントを表す。`hasVoiceAttachment` と `hasImageAttachment` フラグを導入し、添付がある送金の使用率逸脱ペナルティを軽減することで、より意味のあるインタラクションをインセンティブ付けする。

### 仕様

#### 新関数

`PCECommunityToken` に4つの新しいパブリック関数を追加する：

##### 2.1 `transferWithMetadata`

```solidity
function transferWithMetadata(
    address receiver,
    uint256 displayAmount,
    uint256 messageCount,
    bool hasVoiceAttachment,
    bool hasImageAttachment
) public returns (bool);
```

##### 2.2 `transferFromWithMetadata`

```solidity
function transferFromWithMetadata(
    address sender,
    address receiver,
    uint256 displayBalance,
    uint256 messageCount,
    bool hasVoiceAttachment,
    bool hasImageAttachment
) public returns (bool);
```

##### 2.3 `transferWithAuthorizationAndMetadata`

```solidity
function transferWithAuthorizationAndMetadata(
    address from, address to, uint256 displayAmount,
    uint256 validAfter, uint256 validBefore, bytes32 nonce,
    uint8 v, bytes32 r, bytes32 s,
    uint256 messageCount,
    bool hasVoiceAttachment,
    bool hasImageAttachment
) public;
```

**EIP-712 型:**
```
TransferWithAuthorizationAndMetadata(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount,bool hasVoiceAttachment,bool hasImageAttachment)
```

##### 2.4 `transferFromWithAuthorizationAndMetadata`

```solidity
function transferFromWithAuthorizationAndMetadata(
    address spender, address from, address to, uint256 displayAmount,
    uint256 validAfter, uint256 validBefore, bytes32 nonce,
    uint8 v, bytes32 r, bytes32 s,
    uint256 messageCount,
    bool hasVoiceAttachment,
    bool hasImageAttachment
) public;
```

**EIP-712 型:**
```
TransferFromWithAuthorizationAndMetadata(address spender,address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint256 messageCount,bool hasVoiceAttachment,bool hasImageAttachment)
```

#### 添付ファイルによるペナルティ軽減（コミュニティトークンごとに設定可能）

各添付フラグは使用率逸脱ペナルティ（`changeMulBp`）を軽減する。軽減率は**コミュニティトークンごとに設定可能**で、プロトコル全体のデフォルト値は以下の通り：

```
DEFAULT_VOICE_REDUCTION_BP = 1000   // 10%
DEFAULT_IMAGE_REDUCTION_BP = 1000   // 10%
```

##### トークンごとの設定

各 `PCECommunityToken` は独自の軽減率を保持する。明示的に設定されない場合、上記デフォルト値が使用される。

```solidity
// ストレージ
uint256 public voiceReductionBp;   // DEFAULT_VOICE_REDUCTION_BP で初期化
uint256 public imageReductionBp;   // DEFAULT_IMAGE_REDUCTION_BP で初期化

// セッター（オーナーのみ）
function setAttachmentReductionBp(
    uint256 _voiceReductionBp,
    uint256 _imageReductionBp
) external onlyOwner;
```

**制約:**
- 各値の範囲は `[0, 5000]`（0%〜50%）
- `voiceReductionBp + imageReductionBp` の合計は `5000`（50%）を超えてはならない。ペナルティが半分以上軽減されることを防ぐ

##### ペナルティ軽減の計算式

```
attachmentReductionBp = 0
if hasVoiceAttachment: attachmentReductionBp += voiceReductionBp
if hasImageAttachment: attachmentReductionBp += imageReductionBp

effectiveChangeMulBp = changeMulBp × (BP_BASE - attachmentReductionBp) / BP_BASE

increaseBp = maxIncreaseBp - (effectiveChangeMulBp × messageBp) / BP_BASE
```

| 添付 | デフォルトペナルティ軽減率 | 効果 |
|------|--------------------------|------|
| なし | 0% | `effectiveChangeMulBp = changeMulBp`（変更なし） |
| 音声のみ | 10% | `effectiveChangeMulBp = changeMulBp × 9000 / 10000` |
| 画像のみ | 10% | `effectiveChangeMulBp = changeMulBp × 9000 / 10000` |
| 音声 + 画像 | 20% | `effectiveChangeMulBp = changeMulBp × 8000 / 10000` |

音声と画像の両方を添付した送金は、逸脱ペナルティが20%軽減され、`increaseBp` が大きくなり、より多くの ARIGATO CREATION がミントされる。コミュニティトークンのオーナーは `setAttachmentReductionBp` を呼び出して、自コミュニティのエンゲージメントパターンに合わせた軽減率に調整できる。

#### 変更なしの動作

- 既存の `transfer`、`transferFrom`、`transferWithAuthorization`、`transferFromWithAuthorization` は**変更なし**。破壊的変更なし
- `messageCount` は既存の `MAX_CHARACTER_LENGTH` 定数（`10`）によりクランプされる

#### 新イベント

```solidity
event TransferWithMetadata(
    address indexed from,
    address indexed to,
    uint256 displayAmount,
    uint256 messageCount,
    bool hasVoiceAttachment,
    bool hasImageAttachment
);

event AttachmentReductionBpUpdated(
    uint256 voiceReductionBp,
    uint256 imageReductionBp
);
```

### 影響と互換性

- **後方互換性**: 完全に後方互換。既存の関数は変更なし
- **ストレージ**: 各コミュニティトークンに `uint256` のストレージ変数2つ（`voiceReductionBp`、`imageReductionBp`）を追加。デプロイ/アップグレード時にデフォルト値で初期化
- **フロントエンド**: メタデータ対応のARIGATO CREATIONを活用するアプリは新関数を呼び出す必要あり
- **リレイヤー**: 新しい EIP-712 タイプハッシュで署名構築が必要
- **ガバナンス**: コミュニティトークンのオーナーは、コントラクトアップグレードなしでペナルティ軽減率を調整可能

### 設計根拠

- **なぜ既存関数の変更ではなく新関数か？** ERC-20互換性とリレイヤー連携の維持
- **なぜブーリアンフラグか？** ABIで自己文書化、フロントエンド開発者に扱いやすい。EVMが単一スロットにパック
- **なぜ添付フラグをEIP-712署名に含めるか？** リレイヤーやフロントランナーによる改ざん防止
- **なぜコミュニティトークンごとに設定可能か？** コミュニティごとにエンゲージメントパターンが異なる。ビジュアルアート中心のコミュニティは画像添付の軽減率を高くし、音声チャット中心のコミュニティは音声添付を重視できる。プロトコルレベルの変更なしで各コミュニティがインセンティブを調整可能。デフォルト値（各10%）が合理的な出発点を提供
- **なぜ合計軽減率を50%に制限するか？** ペナルティカーブは健全な使用率分布を維持するコアメカニズム。50%を超える軽減はペナルティを無効化し、ARIGATO CREATIONアルゴリズムのゲーミングを可能にするリスクがある

### 備考

- `messageCount` は送金に関連するメッセージ文字数を表す。値 `0` は `1` として扱われる
- `hasVoiceAttachment` と `hasImageAttachment` はそれぞれ設定可能なペナルティ軽減を適用。加算的にスタック（音声+画像 = 両方の軽減率の合計）
- コミュニティトークンのオーナーは `setAttachmentReductionBp` をいつでも呼び出して軽減率を調整可能。両方を `0` に設定すると、そのトークンの添付軽減機能を実質的に無効化する

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)