### PR TITLE
PIP-16: Owner-controlled Token Value Operations (supersedes PIP-12)

### DIFF
--- a/PIPs/pip-16.md
+++ b/PIPs/pip-16.md
@@ -1,0 +1,211 @@
+---
+pip: 16
+title: Owner-controlled Token Value Operations (supersedes PIP-12)
+proposer: CHIBA Masahiro (@nihen)
+status: Draft
+type: Core
+created: 2026-04-26
+requires: []
+replaces: [12]
+---
+
+## PIP-16: Owner-controlled Token Value Operations
+
+### Abstract
+
+This proposal supersedes PIP-12 with a simplified design. It introduces token value increase and token split operations on PCECommunityToken that adjust the swap rate (`exchangeRate`), gated by `onlyOwner`. The dedicated `RATE_MANAGER_ROLE` and `treasuryWallet` storage proposed in PIP-12 are removed; PCE reserves are pulled from `msg.sender` (i.e. the contract owner). Communities that want to govern these operations on Tally simply transfer ownership to a Governor + Timelock setup, which makes the Timelock both the operation authority and the on-chain treasury (this is the standard Tally Treasury pattern).
+
+### Motivation
+
+PIP-12 introduced a `RATE_MANAGER_ROLE` with a custom mapping-based role system and a separate `treasuryWallet` address, motivated by the assumption that operation authority and PCE custody could live at different addresses, and that owner authority needed to be split off. Subsequent design review revealed that:
+
+1. PCECommunityToken's `owner` is set to the community creator at `createToken` time (not the protocol owner). It is community-scoped from the start.
+2. Communities that govern these operations through Tally inevitably converge to `owner = Governor's Timelock = Tally Treasury = PCE custody`. In that pattern there is no benefit to splitting `owner` from `RATE_MANAGER` or to keeping a separate `treasuryWallet`.
+3. The split adds storage variables (`treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`), administrative functions (`initializeTreasury` / `setTreasuryWallet` / `grantRateManagerRole` / `revokeRateManagerRole` / `hasRole`), and bytecode to a contract that has been near the Polygon 32 KB limit (see commit `cc07abf`). The cost is real; the benefit was hypothetical.
+
+PIP-12 was cancelled on the Polygon Timelock before its implementation switch executed (cancellation tx: `0xe4ed89b0846ce643b29b528e1e2fbe247a51867235ba88cf1760fd944661e1fb` on 2026-04-26). This proposal redesigns the same economic mechanism in the simplest form that meets the actual requirement.
+
+This proposal enables:
+- Community operators (or, after `transferOwnership`, the community's Governor + Timelock) to add PCE reserves to increase token value
+- The same authority to expand token supply via proportional distribution to all holders (token split)
+- Adjustment of the swap rate through reserve management and supply expansion
+
+### Specification
+
+#### Interface
+
+The following interfaces are added to the respective contracts.
+
+**PCECommunityToken — new functions:**
+
+```solidity
+function increaseTokenValue(uint256 pceAmount) external;
+function splitToken(uint256 mintAmount) external;
+```
+
+Both functions are gated by `onlyOwner`. No new role-management functions are introduced.
+
+**PCEToken — new functions:**
+
+```solidity
+function addReserve(address communityToken, uint256 pceAmount) external;
+```
+
+The caller (the PCECommunityToken contract) MUST forward `msg.sender` of the original `increaseTokenValue` call as the source of PCE via `transferFrom`. Implementations can pass this address as an additional parameter or have PCECommunityToken pull PCE from its caller and transfer it to PCEToken in a single internal step. The exact internal interface is left to the implementation provided that the externally observable behaviour matches this specification.
+
+#### Storage
+
+The following storage variables are added to `PCECommunityToken`:
+
+```solidity
+uint256 public rebaseFactor; // initialized lazily; treated as INITIAL_FACTOR (1e18) when zero
+```
+
+All new variables MUST be appended to the end of existing storage. Existing storage slots MUST NOT be modified.
+
+The PIP-12-only variables (`treasuryWallet`, `_roles`, role-related constants) are NOT introduced. PIP-12's PR was cancelled before any Beacon implementation switch took effect, so no compatibility shim is required.
+
+#### Events
+
+```solidity
+event TokenValueIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
+event TokenSplit(uint256 mintAmount, uint256 oldExchangeRate, uint256 newExchangeRate, uint256 oldRebaseFactor, uint256 newRebaseFactor);
+```
+
+The PIP-12 events `TreasuryWalletSet`, `RateManagerRoleGranted`, and `RateManagerRoleRevoked` are removed.
+
+#### Token Value Increase
+
+Transfers PCE from the caller (the contract owner) to the PCEToken contract and adjusts the swap rate downward, increasing the per-token PCE value of every existing holder.
+
+1. The caller (i.e. the owner of the PCECommunityToken) MUST have approved at least `pceAmount` of PCE to the PCEToken contract in advance.
+2. Transfer `pceAmount` of PCE from the caller to the PCEToken contract via `transferFrom`.
+3. Increase `depositedPCEToken` by `pceAmount`.
+4. Adjust `exchangeRate`: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`.
+5. No community tokens are minted.
+6. Emit `TokenValueIncreased`.
+
+#### Token Split
+
+Adjusts the rebase factor to mint new community tokens and distributes them proportionally to all existing holders. PCE reserves are NOT withdrawn. The swap rate is adjusted upward to reflect the increased token supply, decreasing the per-token PCE value.
+
+1. `mintAmount` is specified in the display (post-rebase) unit of the community token.
+2. Adjust `rebaseFactor`: `newRebaseFactor = oldRebaseFactor * (totalDisplaySupply + mintAmount) / totalDisplaySupply`.
+3. All holders' display balances increase proportionally: `newDisplayBalance = oldDisplayBalance * newRebaseFactor / oldRebaseFactor`.
+4. Adjust `exchangeRate`: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`.
+5. `depositedPCEToken` is unchanged.
+6. No PCE moves.
+7. Emit `TokenSplit`.
+
+The display balance computation incorporates the rebase factor: `displayBalance = rawBalance * INITIAL_FACTOR / getCurrentFactor() * rebaseFactor / INITIAL_FACTOR` (with `rebaseFactor` treated as `INITIAL_FACTOR` when zero, so existing tokens behave identically until a split happens).
+
+#### Symmetry
+
+| | Token Value Increase | Token Split |
+|---|---|---|
+| PCE flow | caller → PCEToken contract | none |
+| `depositedPCEToken` | increased | unchanged |
+| `exchangeRate` | adjusted down (token value ↑) | adjusted up (token value ↓) |
+| Token supply | unchanged | increased (via rebase factor) |
+| `rebaseFactor` | unchanged | increased |
+| Holder balances | unchanged | all increased proportionally |
+
+#### Authority
+
+Both operations are gated by `onlyOwner`. There is no separate role:
+
+- For self-managed communities, the `owner` is the community creator's EOA (the address that called `createToken`); they call these functions directly.
+- For governance-managed communities, the community deploys an OZ Governor + TimelockController and calls `transferOwnership(timelock)`. Tally renders the Timelock as the DAO Treasury; PCE held by the Timelock is what feeds `increaseTokenValue`. Proposals are batched: `approve(PCEToken, amount)` from the Timelock + `increaseTokenValue(amount)` in the same batch.
+- Migration between the two modes is performed via standard `transferOwnership`. No PIP-specific migration step is required.
+
+### Rationale
+
+**Why `onlyOwner` instead of a dedicated role?**
+The `owner` of PCECommunityToken is already community-scoped (assigned at `createToken` to the creator). Communities that need governance simply set `owner` to a Governor's Timelock; communities that operate informally keep `owner` on a multisig or EOA. A separate `RATE_MANAGER_ROLE` is only beneficial if `owner` and the rate-changing authority are intended to live at different addresses, which has no concrete operational use case. Aligning all governable operations (`setTokenSettings`, `increaseTokenValue`, `splitToken`) under the same authority keeps the mental model and the Tally proposal flow coherent.
+
+**Why no `treasuryWallet`?**
+The PCE used for token value increases is held wherever the community's PCE custody lives. When governance is on Tally, that is the Timelock, which is also the caller of `increaseTokenValue`, so `msg.sender` is the correct and only address to pull PCE from. A separate `treasuryWallet` would only matter if the rate-changing authority and the PCE custodian were intentionally different addresses; in practice they are not. Removing the slot also removes the management surface (`initializeTreasury`, `setTreasuryWallet`).
+
+**Why use a factor-based rebase rather than iterating holders?**
+Iterating all holders on-chain is gas-prohibitive and would require maintaining an enumerable holder set. A factor-based approach achieves O(1) gas regardless of holder count and is consistent with PCECommunityToken's existing demurrage factor pattern.
+
+**Why adjust `exchangeRate` for token value increases?**
+Minting would dilute existing holders. Adjusting `exchangeRate` changes the per-token PCE value uniformly across all community tokens without touching balances or total supply.
+
+**Why use rebase distribution rather than PCE withdrawal for token splits?**
+PCE withdrawal to a treasury would deplete the reserves backing the community token. Rebase keeps PCE reserves intact and instead expands token supply proportionally. No value leaves the system; the economic effect is uniform supply expansion (analogous to a stock split), preserving each holder's ownership share while adjusting the per-token value.
+
+**Comparison to PIP-12.**
+| | PIP-12 | PIP-16 (this) |
+|---|---|---|
+| Authority for value ops | dedicated `RATE_MANAGER_ROLE` | `onlyOwner` |
+| PCE source | `treasuryWallet` (separate slot) | `msg.sender` (i.e. owner) |
+| Storage added (`PCECommunityToken`) | `treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`, `rebaseFactor` | `rebaseFactor` only |
+| Admin functions added | `initializeTreasury`, `setTreasuryWallet`, `grantRateManagerRole`, `revokeRateManagerRole`, `hasRole` | none |
+| Events added | 5 | 2 |
+| Migration path to DAO governance | grant role + set treasury | `transferOwnership` (already supported) |
+| Bytecode impact | larger (relevant given Polygon 32 KB ceiling) | minimal |
+
+### Backwards Compatibility
+
+All changes are additive: new functions, one new storage variable (`rebaseFactor`) appended to existing storage, two new events. Existing function signatures and behaviour are unchanged.
+
+PIP-12 was cancelled on the Polygon Timelock before its Beacon implementation switch executed, so its proposed storage layout (`treasuryWallet`, `_roles`) was never committed on Production or DEV. PIP-16 therefore starts from the current v15 storage layout with no conflicts.
+
+`rebaseFactor` is treated as `INITIAL_FACTOR` (1e18) when zero, so PCECommunityTokens that have never been split continue to compute display balances identically to before the upgrade.
+
+### Test Cases
+
+All examples use `INITIAL_FACTOR = 10^18`.
+
+**Case 1: Token value increase**
+- Initial: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`
+- Owner has approved 50e18 PCE to PCEToken
+- Operation: `increaseTokenValue(50e18)`
+- Result: `depositedPCEToken = 150e18`, `exchangeRate = 1e18 * 100e18 / 150e18 ≈ 0.667e18`
+- Effect: Per-token PCE value of every holder increases.
+
+**Case 2: Token split (supply expansion)**
+- Initial: `totalDisplaySupply = 200e18`, `exchangeRate = 1e18`, `rebaseFactor = 1e18`
+- Operation: `splitToken(50e18)`
+- Result: `rebaseFactor = 1.25e18`, `exchangeRate = 1.25e18`
+- Effect: All holders' display balances increase by 25 %. Per-token PCE value decreases. `depositedPCEToken` is unchanged. Each holder's PCE-equivalent total is unchanged.
+
+**Case 3: Token split preserves ownership shares**
+- Initial: Alice 100 (50 %), Bob 100 (50 %), `totalDisplaySupply = 200e18`
+- Operation: `splitToken(100e18)`
+- Result: Alice 150 (50 %), Bob 150 (50 %), `totalDisplaySupply = 300e18`
+
+**Case 4: Unauthorised access**
+- A non-owner account calls `increaseTokenValue(10e18)`
+- Result: revert (`Ownable: caller is not the owner`)
+
+**Case 5: Insufficient approval**
+- Owner has approved 0 PCE to PCEToken
+- Operation: `increaseTokenValue(10e18)`
+- Result: revert (`ERC20InsufficientAllowance` from PCEToken)
+
+**Case 6: Governance flow (Tally)**
+- Owner of the PCECommunityToken is a Polygon TimelockController.
+- A Governor proposal batches: (a) `PCEToken.approve(communityToken, amount)` from the Timelock, (b) `communityToken.increaseTokenValue(amount)`.
+- Both calls execute as `msg.sender = Timelock`.
+- Result: PCE leaves the Timelock (Tally Treasury) and is added to the reserves; `exchangeRate` adjusts.
+
+### Security Considerations
+
+**Compromise of the owner.** A compromised owner can call `splitToken` repeatedly to dilute the per-token PCE value, or can drain its own approved PCE via `increaseTokenValue`. PCE never leaves the system as a result of `splitToken`, so the attack surface for value-extraction is bounded by the owner's own PCE balance and approval. Communities SHOULD use a multisig or DAO Governor + Timelock for the owner role. The governance model is out of scope for this proposal.
+
+**Front-running.** A user MAY attempt to front-run a pending `splitToken` transaction with a `swapFromLocalToken` at the pre-split rate. Because no PCE leaves reserves on a split, the impact is limited to rate arbitrage. Mitigation strategies (commit-reveal, private mempools, etc.) are out of scope.
+
+**Reentrancy.** `increaseTokenValue` performs an external call (`transferFrom`). `splitToken` is purely internal (factor adjustment, no external calls). Implementations MUST either follow the checks-effects-interactions pattern or use a reentrancy guard for `increaseTokenValue`.
+
+**Integer overflow / underflow.** Rate computations multiply before dividing. Implementations MUST use `Math.mulDiv` or equivalent safe-math primitives to prevent precision loss and overflow.
+
+**Approval grant requirement.** `increaseTokenValue` relies on a prior `approve` from the owner. In the Tally / Timelock flow this is provided by including the `approve` call in the same proposal batch as `increaseTokenValue`, which guarantees atomicity within the batch executor.
+
+### Notes
+
+- **Scope of changes**: Upgrades to both PCEToken and PCECommunityToken are required. Implementation lives behind the existing UUPS proxy / Beacon proxy.
+- **PIP-12 status**: Cancelled at the Polygon Timelock layer before any Beacon implementation switch executed. Cancellation tx: `0xe4ed89b0846ce643b29b528e1e2fbe247a51867235ba88cf1760fd944661e1fb` (Polygon, 2026-04-26). PIP-12 SHOULD be marked `Withdrawn` once this proposal is finalised.
+- **Out of scope**: Treasury / custody arrangements (multisig, DAO governance, etc.) are at each community's discretion. Community dissolution is left to a separate proposal.
+- **Dependencies**: None (built on the existing UUPS / Beacon proxy infrastructure introduced by prior PIPs).

--- a/PIPs/pip-16.md
+++ b/PIPs/pip-16.md
@@ -80,7 +80,7 @@ The PIP-12 events `TreasuryWalletSet`, `RateManagerRoleGranted`, and `RateManage
 Transfers PCE from the community owner to the PCEToken contract and adjusts the swap rate downward, increasing the per-token PCE value of every existing holder.
 
 1. The community owner MUST have approved at least `pceAmount` of PCE to the PCEToken contract in advance.
-2. Transfer `pceAmount` of PCE from the community owner to the PCEToken contract via the standing approval (the PCEToken contract pulls the PCE internally; no separate `transferFrom` call from the caller is required).
+2. Transfer `pceAmount` of PCE from the community owner to the PCEToken contract via the standing approval.
 3. Increase `depositedPCEToken` by `pceAmount`.
 4. Adjust `exchangeRate`: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`.
 5. No community tokens are minted.

--- a/PIPs/pip-16.md
+++ b/PIPs/pip-16.md
@@ -92,25 +92,29 @@ Both events are emitted from PCEToken so the `communityToken` index identifies w
 Transfers PCE from the community owner directly to the PCEToken contract and adjusts the swap rate downward, increasing the per-token PCE value of every existing holder.
 
 1. Verify `localTokens[communityToken].isExists == true` and `OwnableUpgradeable(communityToken).owner() == msg.sender`.
-2. Transfer `pceAmount` of PCE from `msg.sender` to the PCEToken contract via the contract's internal `_transfer`. No prior `approve` is required because PCEToken is itself the PCE ERC20 contract and the caller is verified to be the community owner.
-3. Increase `depositedPCEToken` by `pceAmount`.
-4. Adjust `exchangeRate`: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`.
-5. No community tokens are minted.
-6. Emit `TokenValueIncreased(communityToken, pceAmount, oldRate, newRate)`.
+2. Update PCEToken's global demurrage factor (`updateFactorIfNeeded()`) so the contract's factor state stays consistent with other token-moving entrypoints (`transfer`, `transferFrom`, `swapFromLocalToken`, etc.).
+3. Transfer `pceAmount` of PCE from `msg.sender` to the PCEToken contract via the contract's internal `_transfer`. No prior `approve` is required because PCEToken is itself the PCE ERC20 contract and the caller is verified to be the community owner.
+4. Increase `depositedPCEToken` by `pceAmount`.
+5. Adjust `exchangeRate`:
+   - if `oldDeposited == 0`: keep `newRate = oldRate`. The proportional formula collapses to zero when reserves are fully drained, which would brick all subsequent swaps; preserving the prior rate lets a community recover from the drained state.
+   - otherwise: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`.
+6. No community tokens are minted.
+7. Emit `TokenValueIncreased(communityToken, pceAmount, oldRate, newRate)`.
 
 #### Token Split
 
 Adjusts the rebase factor to mint new community tokens and distributes them proportionally to all existing holders. PCE reserves are NOT withdrawn. The swap rate is adjusted upward to reflect the increased token supply, decreasing the per-token PCE value.
 
 1. Verify `localTokens[communityToken].isExists == true` and `OwnableUpgradeable(communityToken).owner() == msg.sender`. Verify the community token's current `totalSupply()` is greater than zero.
-2. `mintAmount` is specified in the display (post-rebase) unit of the community token.
-3. Compute `newRebaseFactor = oldRebaseFactor * (totalDisplaySupply + mintAmount) / totalDisplaySupply`. (`oldRebaseFactor` is treated as `INITIAL_FACTOR` when zero, so the first split on a never-split community works correctly.)
-4. Call `PCECommunityToken.applyRebase(newRebaseFactor)` on the community token to commit the new factor.
-5. All holders' display balances increase proportionally because the community token's `balanceOf` / `totalSupply` computation incorporates `rebaseFactor`.
-6. Adjust `exchangeRate`: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`.
-7. `depositedPCEToken` is unchanged.
-8. No PCE moves.
-9. Emit `TokenSplit(communityToken, mintAmount, oldRate, newRate, oldRebaseFactor, newRebaseFactor)`.
+2. Update PCEToken's global demurrage factor (`updateFactorIfNeeded()`), as in Token Value Increase, to keep factor state consistent with other entrypoints.
+3. `mintAmount` is specified in the display (post-rebase) unit of the community token.
+4. Compute `newRebaseFactor = oldRebaseFactor * (totalDisplaySupply + mintAmount) / totalDisplaySupply`. (`oldRebaseFactor` is treated as `INITIAL_FACTOR` when zero, so the first split on a never-split community works correctly.)
+5. Call `PCECommunityToken.applyRebase(newRebaseFactor)` on the community token to commit the new factor.
+6. All holders' display balances increase proportionally because the community token's `balanceOf` / `totalSupply` computation incorporates `rebaseFactor`.
+7. Adjust `exchangeRate`: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`.
+8. `depositedPCEToken` is unchanged.
+9. No PCE moves.
+10. Emit `TokenSplit(communityToken, mintAmount, oldRate, newRate, oldRebaseFactor, newRebaseFactor)`.
 
 The display balance computation incorporates the rebase factor: `displayBalance = rawBalance * INITIAL_FACTOR / getCurrentFactor() * rebaseFactor / INITIAL_FACTOR` (with `rebaseFactor` treated as `INITIAL_FACTOR` when zero, so existing tokens behave identically until a split happens).
 
@@ -212,6 +216,12 @@ All examples use `INITIAL_FACTOR = 10^18`.
 - A Governor proposal contains a single call: `pceToken.increaseTokenValue(communityToken, amount)`.
 - The call executes under the Timelock as `msg.sender`, which equals `OwnableUpgradeable(communityToken).owner()`, so authorisation passes.
 - Result: PCE leaves the Timelock (the community's on-chain treasury) and is added to the reserves; `exchangeRate` adjusts.
+
+**Case 7: Recovery after fully drained reserve**
+- Initial: `depositedPCEToken == 0` (reserves fully drained, e.g. via repeated `swapFromLocalToken` and `swapFeeFromLocalToken`); `exchangeRate == R` (positive).
+- Operation: community owner calls `pceToken.increaseTokenValue(communityToken, X)` with `X > 0`.
+- Result: `depositedPCEToken == X`; `exchangeRate == R` (unchanged, because the fallback branch keeps the prior rate when `oldDeposited == 0`).
+- Effect: Future swaps against the community token function correctly because the rate is non-zero.
 
 ### Security Considerations
 

--- a/PIPs/pip-16.md
+++ b/PIPs/pip-16.md
@@ -13,7 +13,7 @@ replaces: [12]
 
 ### Abstract
 
-This proposal supersedes PIP-12 with a simplified design. It introduces token value increase and token split operations on PCECommunityToken that adjust the swap rate (`exchangeRate`), gated by `onlyOwner`. The dedicated `RATE_MANAGER_ROLE` and `treasuryWallet` storage proposed in PIP-12 are removed; PCE reserves are pulled from the community owner. Communities that want to govern these operations through a DAO simply transfer ownership to a Governor + Timelock setup, which makes the Timelock both the operation authority and the on-chain treasury for the community.
+This proposal supersedes PIP-12 with a simplified design. It adds two operations that adjust the swap rate (`exchangeRate`) of a community token: `increaseTokenValue` and `splitToken`. Both live on the PCEToken contract — the same contract that already hosts the swap operations between PCE and community tokens — and are gated to the community owner (the owner of the community's PCECommunityToken). The dedicated `RATE_MANAGER_ROLE` and `treasuryWallet` storage proposed in PIP-12 are removed; PCE reserves are pulled directly from the caller, who is the community owner. Communities that want to govern these operations through a DAO simply transfer ownership of their community token to a Governor + Timelock setup, which makes the Timelock both the operation authority and the on-chain treasury for the community.
 
 ### Motivation
 
@@ -33,30 +33,28 @@ This proposal enables:
 
 #### Interface
 
-The following interfaces are added to the respective contracts.
-
-**PCECommunityToken — new functions:**
-
-```solidity
-function increaseTokenValue(uint256 pceAmount) external;
-function splitToken(uint256 mintAmount) external;
-```
-
-Both functions are gated by `onlyOwner`. No new role-management functions are introduced.
+The following interfaces are added to PCEToken. PCECommunityToken receives one new internal-coordination function (`applyRebase`).
 
 **PCEToken — new functions:**
 
 ```solidity
-function addReserve(address communityToken, uint256 pceAmount) external;
+function increaseTokenValue(address communityToken, uint256 pceAmount) external;
+function splitToken(address communityToken, uint256 mintAmount) external;
 ```
 
-`addReserve` MUST be called only by the registered PCECommunityToken contract (enforced by `require(msg.sender == communityToken)` and `localTokens[communityToken].isExists`). PCE is pulled from the community owner (the address returned by `OwnableUpgradeable(communityToken).owner()`) via the standing approval that the community owner has granted to the PCEToken contract.
+Both functions verify the caller is the community owner via `OwnableUpgradeable(communityToken).owner() == msg.sender`. The community token must be registered (`localTokens[communityToken].isExists == true`).
 
-**Note: `addReserve` is not a client-facing entrypoint.** It is an internal coordination function between the two contracts: PCECommunityToken's `increaseTokenValue` calls `addReserve` to atomically update `depositedPCEToken` accounting (which lives on PCEToken), pull PCE from the community owner (using PCEToken's own ERC20 internals), and adjust `exchangeRate`. Clients (community owners, multisigs, Timelocks, etc.) interact only with `PCECommunityToken.increaseTokenValue` and `PCECommunityToken.splitToken`. A direct call to `addReserve` from any address other than the registered PCECommunityToken contract reverts. This pattern follows the same convention as the existing `PCECommunityToken.mint` / `PCECommunityToken.recordSwapToPCE` functions, which are similarly gated to only accept calls from PCEToken.
+**PCECommunityToken — new functions:**
+
+```solidity
+function applyRebase(uint256 newFactor) external;
+```
+
+`applyRebase` is gated to `msg.sender == pceAddress` (i.e. only PCEToken can call it). It is the internal-coordination function PCEToken uses during `splitToken` to update the community token's `rebaseFactor`. It is not a client-facing entrypoint and follows the same convention as the existing `mint` / `burnByPCEToken` / `recordSwapToPCE` functions, which are similarly gated to only accept calls from PCEToken. Clients (community owners, multisigs, Timelocks, etc.) interact only with `PCEToken.increaseTokenValue` and `PCEToken.splitToken`.
 
 #### Storage
 
-The following storage variables are added to `PCECommunityToken`:
+The following storage variable is added to `PCECommunityToken`:
 
 ```solidity
 uint256 public rebaseFactor; // initialized lazily; treated as INITIAL_FACTOR (1e18) when zero
@@ -64,39 +62,55 @@ uint256 public rebaseFactor; // initialized lazily; treated as INITIAL_FACTOR (1
 
 All new variables MUST be appended to the end of existing storage. Existing storage slots MUST NOT be modified.
 
-The PIP-12-only variables (`treasuryWallet`, `_roles`, role-related constants) are NOT introduced. PIP-12's PR was cancelled before any Beacon implementation switch took effect, so no compatibility shim is required.
+PIP-12 introduced `treasuryWallet` and a `_roles` mapping. PIP-12's Beacon implementation switch never executed on the Production chain, but DEV had been upgraded directly to a v15 implementation that committed those slots. To allow a single v16 implementation to upgrade both DEV and Production cleanly, the v16 implementation declares `__deprecated_treasuryWallet` and `__deprecated_roles` as private placeholders at the original PIP-12 slot positions (annotated `@custom:oz-renamed-from` for OpenZeppelin upgrade-safety validation). They are unused by PIP-16 logic.
+
+PCEToken adds no new storage.
 
 #### Events
 
 ```solidity
-event TokenValueIncreased(uint256 pceAmount, uint256 oldExchangeRate, uint256 newExchangeRate);
-event TokenSplit(uint256 mintAmount, uint256 oldExchangeRate, uint256 newExchangeRate, uint256 oldRebaseFactor, uint256 newRebaseFactor);
+event TokenValueIncreased(
+    address indexed communityToken,
+    uint256 pceAmount,
+    uint256 oldExchangeRate,
+    uint256 newExchangeRate
+);
+event TokenSplit(
+    address indexed communityToken,
+    uint256 mintAmount,
+    uint256 oldExchangeRate,
+    uint256 newExchangeRate,
+    uint256 oldRebaseFactor,
+    uint256 newRebaseFactor
+);
 ```
 
-The PIP-12 events `TreasuryWalletSet`, `RateManagerRoleGranted`, and `RateManagerRoleRevoked` are removed.
+Both events are emitted from PCEToken so the `communityToken` index identifies which community a given operation applies to. The PIP-12 events `TreasuryWalletSet`, `RateManagerRoleGranted`, and `RateManagerRoleRevoked` are removed.
 
 #### Token Value Increase
 
-Transfers PCE from the community owner to the PCEToken contract and adjusts the swap rate downward, increasing the per-token PCE value of every existing holder.
+Transfers PCE from the community owner directly to the PCEToken contract and adjusts the swap rate downward, increasing the per-token PCE value of every existing holder.
 
-1. The community owner MUST have approved at least `pceAmount` of PCE to the PCEToken contract in advance.
-2. Transfer `pceAmount` of PCE from the community owner to the PCEToken contract via the standing approval.
+1. Verify `localTokens[communityToken].isExists == true` and `OwnableUpgradeable(communityToken).owner() == msg.sender`.
+2. Transfer `pceAmount` of PCE from `msg.sender` to the PCEToken contract via the contract's internal `_transfer`. No prior `approve` is required because PCEToken is itself the PCE ERC20 contract and the caller is verified to be the community owner.
 3. Increase `depositedPCEToken` by `pceAmount`.
 4. Adjust `exchangeRate`: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`.
 5. No community tokens are minted.
-6. Emit `TokenValueIncreased`.
+6. Emit `TokenValueIncreased(communityToken, pceAmount, oldRate, newRate)`.
 
 #### Token Split
 
 Adjusts the rebase factor to mint new community tokens and distributes them proportionally to all existing holders. PCE reserves are NOT withdrawn. The swap rate is adjusted upward to reflect the increased token supply, decreasing the per-token PCE value.
 
-1. `mintAmount` is specified in the display (post-rebase) unit of the community token.
-2. Adjust `rebaseFactor`: `newRebaseFactor = oldRebaseFactor * (totalDisplaySupply + mintAmount) / totalDisplaySupply`.
-3. All holders' display balances increase proportionally: `newDisplayBalance = oldDisplayBalance * newRebaseFactor / oldRebaseFactor`.
-4. Adjust `exchangeRate`: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`.
-5. `depositedPCEToken` is unchanged.
-6. No PCE moves.
-7. Emit `TokenSplit`.
+1. Verify `localTokens[communityToken].isExists == true` and `OwnableUpgradeable(communityToken).owner() == msg.sender`. Verify the community token's current `totalSupply()` is greater than zero.
+2. `mintAmount` is specified in the display (post-rebase) unit of the community token.
+3. Compute `newRebaseFactor = oldRebaseFactor * (totalDisplaySupply + mintAmount) / totalDisplaySupply`. (`oldRebaseFactor` is treated as `INITIAL_FACTOR` when zero, so the first split on a never-split community works correctly.)
+4. Call `PCECommunityToken.applyRebase(newRebaseFactor)` on the community token to commit the new factor.
+5. All holders' display balances increase proportionally because the community token's `balanceOf` / `totalSupply` computation incorporates `rebaseFactor`.
+6. Adjust `exchangeRate`: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`.
+7. `depositedPCEToken` is unchanged.
+8. No PCE moves.
+9. Emit `TokenSplit(communityToken, mintAmount, oldRate, newRate, oldRebaseFactor, newRebaseFactor)`.
 
 The display balance computation incorporates the rebase factor: `displayBalance = rawBalance * INITIAL_FACTOR / getCurrentFactor() * rebaseFactor / INITIAL_FACTOR` (with `rebaseFactor` treated as `INITIAL_FACTOR` when zero, so existing tokens behave identically until a split happens).
 
@@ -113,19 +127,25 @@ The display balance computation incorporates the rebase factor: `displayBalance 
 
 #### Authority
 
-Both operations are gated by `onlyOwner`. There is no separate role:
+Both operations are gated by `OwnableUpgradeable(communityToken).owner() == msg.sender`. There is no separate role:
 
-- For self-managed communities, the community owner is the address that called `createToken` (typically an EOA or multisig); the community owner calls these functions directly.
-- For DAO-managed communities, the community deploys a Governor + TimelockController and calls `transferOwnership(timelock)`. The community's Timelock then becomes the operation authority and the on-chain treasury that holds PCE for `increaseTokenValue`. Proposals are batched: `approve(PCEToken, amount)` from the Timelock + `increaseTokenValue(amount)` in the same batch.
-- Migration between the two modes is performed via standard `transferOwnership`. No PIP-specific migration step is required.
+- For self-managed communities, the community owner is the address that called `createToken` (typically an EOA or multisig); the community owner calls these functions on PCEToken directly.
+- For DAO-managed communities, the community deploys a Governor + TimelockController and calls `transferOwnership(timelock)` on the community token. The community's Timelock then becomes the operation authority and the on-chain treasury that holds PCE for `increaseTokenValue`. A proposal calls `PCEToken.increaseTokenValue(communityToken, amount)` directly; no `approve` is required because the Timelock is the caller and PCEToken pulls PCE from `msg.sender`.
+- Migration between the two modes is performed via standard `transferOwnership` on the community token. No PIP-specific migration step is required.
 
 ### Rationale
 
-**Why `onlyOwner` instead of a dedicated role?**
-The community owner of PCECommunityToken is already community-scoped (assigned at `createToken` to the creator). Communities that need governance simply set the community owner to a Governor's Timelock; communities that operate informally keep the community owner on a multisig or EOA. A separate `RATE_MANAGER_ROLE` is only beneficial if the community owner and the rate-changing authority are intended to live at different addresses, which has no concrete operational use case. Aligning all governable operations (`setTokenSettings`, `increaseTokenValue`, `splitToken`) under the same authority keeps the mental model and the DAO proposal flow coherent.
+**Why are the operations on PCEToken instead of PCECommunityToken?**
+The state mutated by these operations — `localTokens[communityToken].depositedPCEToken` and `.exchangeRate` — lives on PCEToken, alongside the existing swap functions (`swapFromLocalToken`, `swapToLocalToken`, `swapFeeFromLocalToken`). Locating the new operations next to the state and the related swap logic produces a single, coherent surface for all PCE↔community economic operations. It also matches the existing protocol pattern in which PCEToken privileged-calls back into the community token (`mint`, `burnByPCEToken`, `recordSwapToPCE`); `applyRebase` is a new entry in that same pattern. PIP-12 originally placed these operations on the community token because the design centred on a per-community treasury wallet and role system. With those concepts removed, the community-token location no longer has a justification; consolidating on PCEToken eliminates the `addReserve` cross-contract bounce, removes the standing-`approve` requirement, and reduces community-token bytecode (relevant to the Polygon 32 KB ceiling).
+
+**Why `onlyOwner`-equivalent authorisation instead of a dedicated role?**
+The community owner of PCECommunityToken is already community-scoped (assigned at `createToken` to the creator). Communities that need governance simply set the community owner to a Governor's Timelock; communities that operate informally keep the community owner on a multisig or EOA. A separate `RATE_MANAGER_ROLE` is only beneficial if the community owner and the rate-changing authority are intended to live at different addresses, which has no concrete operational use case. Aligning all governable operations under the same authority keeps the mental model and the DAO proposal flow coherent.
 
 **Why no `treasuryWallet`?**
-The PCE used for token value increases is held wherever the community's PCE custody lives. When the community owner is a DAO Timelock, that Timelock is also the caller of `increaseTokenValue`, so the community owner is the correct and only address to pull PCE from. A separate `treasuryWallet` would only matter if the rate-changing authority and the PCE custodian were intentionally different addresses; in practice they are not. Removing the slot also removes the management surface (`initializeTreasury`, `setTreasuryWallet`).
+The PCE used for token value increases is held wherever the community's PCE custody lives. When the community owner is a DAO Timelock, that Timelock is also the caller of `increaseTokenValue`, so the community owner is the correct and only address to pull PCE from. A separate `treasuryWallet` would only matter if the rate-changing authority and the PCE custodian were intentionally different addresses; in practice they are not.
+
+**Why no prior `approve` from the community owner?**
+PCEToken is the PCE ERC20 contract itself. When the community owner calls `PCEToken.increaseTokenValue(...)` directly, the call passes through PCEToken's own ownership context, and PCEToken can use its internal `_transfer(msg.sender, address(this), pceAmount)` without an external `transferFrom` round-trip. This is the same pattern used by the existing `swapFromLocalToken` and `swapToLocalToken` flows, which transfer PCE in and out without requiring users to issue `approve` calls.
 
 **Why use a factor-based rebase rather than iterating holders?**
 Iterating all holders on-chain is gas-prohibitive and would require maintaining an enumerable holder set. A factor-based approach achieves O(1) gas regardless of holder count and is consistent with PCECommunityToken's existing demurrage factor pattern.
@@ -139,19 +159,22 @@ PCE withdrawal to a treasury would deplete the reserves backing the community to
 **Comparison to PIP-12.**
 | | PIP-12 | PIP-16 (this) |
 |---|---|---|
-| Authority for value ops | dedicated `RATE_MANAGER_ROLE` | `onlyOwner` |
-| PCE source | `treasuryWallet` (separate slot) | community owner |
+| Authority for value ops | dedicated `RATE_MANAGER_ROLE` (mapping-based) | community owner check on PCEToken |
+| Operation host contract | PCECommunityToken | PCEToken |
+| Cross-contract round-trip | `community → addReserve → community` | none (PCEToken handles directly) |
+| PCE source | `treasuryWallet` (separate slot) | community owner (= caller of PCEToken) |
+| Standing `approve` from caller | required | not required |
 | Storage added (`PCECommunityToken`) | `treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`, `rebaseFactor` | `rebaseFactor` only |
 | Admin functions added | `initializeTreasury`, `setTreasuryWallet`, `grantRateManagerRole`, `revokeRateManagerRole`, `hasRole` | none |
-| Events added | 5 | 2 |
+| Events added | 5 (split between contracts) | 2 (both on PCEToken, indexed by `communityToken`) |
 | Migration path to DAO governance | grant role + set treasury | `transferOwnership` (already supported) |
-| Bytecode impact | larger (relevant given Polygon 32 KB ceiling) | minimal |
+| Bytecode impact (community token) | larger (relevant given Polygon 32 KB ceiling) | smaller than PIP-12 by ~1.5 KB |
 
 ### Backwards Compatibility
 
-All changes are additive: new functions, one new storage variable (`rebaseFactor`) appended to existing storage, two new events. Existing function signatures and behaviour are unchanged.
+All changes are additive: new functions on PCEToken, one new internal-coordination function on PCECommunityToken (`applyRebase`), one new storage variable (`rebaseFactor`) appended to existing storage, two new events. Existing function signatures and behaviour are unchanged.
 
-PIP-12 was cancelled on the Polygon Timelock before its Beacon implementation switch executed, so its proposed storage layout (`treasuryWallet`, `_roles`) was never committed on Production. PIP-16 therefore starts from the current production storage layout with no conflicts.
+PIP-12 was cancelled on the Polygon Timelock before its Beacon implementation switch executed, so its proposed storage layout was never committed on Production. PIP-16 starts from the current Production storage layout with no conflicts. DEV had been upgraded directly to a v15 implementation that did commit the PIP-12 slots; v16 retains those slots as `__deprecated_*` private placeholders so a single v16 implementation upgrades both environments cleanly.
 
 `rebaseFactor` is treated as `INITIAL_FACTOR` (1e18) when zero, so PCECommunityTokens that have never been split continue to compute display balances identically to before the upgrade.
 
@@ -160,49 +183,47 @@ PIP-12 was cancelled on the Polygon Timelock before its Beacon implementation sw
 All examples use `INITIAL_FACTOR = 10^18`.
 
 **Case 1: Token value increase**
-- Initial: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`
-- Community owner has approved 50e18 PCE to PCEToken
-- Operation: `increaseTokenValue(50e18)`
+- Initial: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`, community owner holds 100e18 PCE
+- Operation: community owner calls `pceToken.increaseTokenValue(communityToken, 50e18)`
 - Result: `depositedPCEToken = 150e18`, `exchangeRate = 1e18 * 100e18 / 150e18 ≈ 0.667e18`
-- Effect: Per-token PCE value of every holder increases.
+- Effect: Per-token PCE value of every holder increases. Community owner's PCE balance decreases by 50e18.
 
 **Case 2: Token split (supply expansion)**
 - Initial: `totalDisplaySupply = 200e18`, `exchangeRate = 1e18`, `rebaseFactor = 1e18`
-- Operation: `splitToken(50e18)`
+- Operation: community owner calls `pceToken.splitToken(communityToken, 50e18)`
 - Result: `rebaseFactor = 1.25e18`, `exchangeRate = 1.25e18`
 - Effect: All holders' display balances increase by 25 %. Per-token PCE value decreases. `depositedPCEToken` is unchanged. Each holder's PCE-equivalent total is unchanged.
 
 **Case 3: Token split preserves ownership shares**
 - Initial: Alice 100 (50 %), Bob 100 (50 %), `totalDisplaySupply = 200e18`
-- Operation: `splitToken(100e18)`
+- Operation: `splitToken(communityToken, 100e18)`
 - Result: Alice 150 (50 %), Bob 150 (50 %), `totalDisplaySupply = 300e18`
 
-**Case 4: Unauthorised access**
-- A non-owner account calls `increaseTokenValue(10e18)`
-- Result: revert (`Ownable: caller is not the owner`)
+**Case 4: Unauthorised access (non-owner caller)**
+- A non-owner account calls `pceToken.increaseTokenValue(communityToken, 10e18)` or `pceToken.splitToken(communityToken, 10e18)`
+- Result: revert (`Only community owner`)
 
-**Case 5: Insufficient approval**
-- Community owner has approved 0 PCE to PCEToken
-- Operation: `increaseTokenValue(10e18)`
-- Result: revert (`ERC20InsufficientAllowance` from PCEToken)
+**Case 5: applyRebase access control**
+- A non-PCEToken caller calls `communityToken.applyRebase(2e18)`
+- Result: revert (`Only PCE token`)
 
 **Case 6: DAO governance flow**
 - Community owner of the PCECommunityToken is a TimelockController.
-- A Governor proposal batches: (a) `PCEToken.approve(PCEToken, amount)` from the Timelock, (b) `communityToken.increaseTokenValue(amount)`.
-- Both calls execute under the Timelock as the community owner.
+- A Governor proposal contains a single call: `pceToken.increaseTokenValue(communityToken, amount)`.
+- The call executes under the Timelock as `msg.sender`, which equals `OwnableUpgradeable(communityToken).owner()`, so authorisation passes.
 - Result: PCE leaves the Timelock (the community's on-chain treasury) and is added to the reserves; `exchangeRate` adjusts.
 
 ### Security Considerations
 
-**Compromise of the community owner.** A compromised community owner can call `splitToken` repeatedly to dilute the per-token PCE value, or can drain its own approved PCE via `increaseTokenValue`. PCE never leaves the system as a result of `splitToken`, so the attack surface for value-extraction is bounded by the community owner's own PCE balance and approval. Communities SHOULD use a multisig or DAO Governor + Timelock for the community owner role. The governance model is out of scope for this proposal.
+**Compromise of the community owner.** A compromised community owner can call `splitToken` repeatedly to dilute the per-token PCE value, or can drain its own PCE via `increaseTokenValue`. PCE never leaves the system as a result of `splitToken`, so the attack surface for value-extraction is bounded by the community owner's own PCE balance. Communities SHOULD use a multisig or DAO Governor + Timelock for the community owner role. The governance model is out of scope for this proposal.
 
 **Front-running.** A user MAY attempt to front-run a pending `splitToken` transaction with a `swapFromLocalToken` at the pre-split rate. Because no PCE leaves reserves on a split, the impact is limited to rate arbitrage. Mitigation strategies (commit-reveal, private mempools, etc.) are out of scope.
 
-**Reentrancy.** `increaseTokenValue` performs an external call (the internal pull from the community owner). `splitToken` is purely internal (factor adjustment, no external calls). Implementations MUST either follow the checks-effects-interactions pattern or use a reentrancy guard for `increaseTokenValue`.
+**Reentrancy.** `increaseTokenValue` performs an internal `_transfer` (no external call from PCEToken). `splitToken` performs one external call into the registered PCECommunityToken (`applyRebase`). The PCECommunityToken set is governed and constrained to the registered community token implementations, so the external call cannot be redirected to arbitrary code. Implementations SHOULD nonetheless follow the checks-effects-interactions pattern when extending these functions.
 
 **Integer overflow / underflow.** Rate computations multiply before dividing. Implementations MUST use `Math.mulDiv` or equivalent safe-math primitives to prevent precision loss and overflow.
 
-**Approval grant requirement.** `increaseTokenValue` relies on a prior `approve` from the community owner. In the DAO / Timelock flow this is provided by including the `approve` call in the same proposal batch as `increaseTokenValue`, which guarantees atomicity within the batch executor.
+**Authorisation check ordering.** PCEToken validates the registration check (`isExists`) before the ownership check (`owner() == msg.sender`). This ordering is important so that a malicious unregistered contract cannot influence the ownership probe (e.g. by reverting). Implementations MUST keep the registration check first.
 
 ### Notes
 

--- a/PIPs/pip-16.md
+++ b/PIPs/pip-16.md
@@ -19,9 +19,8 @@ This proposal supersedes PIP-12 with a simplified design. It introduces token va
 
 PIP-12 introduced a `RATE_MANAGER_ROLE` with a custom mapping-based role system and a separate `treasuryWallet` address, motivated by the assumption that operation authority and PCE custody could live at different addresses, and that the community owner authority needed to be split off. Subsequent design review revealed that:
 
-1. PCECommunityToken's community owner is set at `createToken` time (the address that created the community). It is community-scoped from the start and is unrelated to any protocol-level owner.
-2. Communities that govern these operations through a DAO inevitably converge to `community owner = Governor's Timelock = community treasury = PCE custody`. In that pattern there is no benefit to splitting the community owner from a separate `RATE_MANAGER` or to keeping a separate `treasuryWallet`.
-3. The split adds storage variables (`treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`), administrative functions (`initializeTreasury` / `setTreasuryWallet` / `grantRateManagerRole` / `revokeRateManagerRole` / `hasRole`), and bytecode to a contract that has been near the Polygon 32 KB limit (see commit `cc07abf`). The cost is real; the benefit was hypothetical.
+1. Communities that govern these operations through a DAO inevitably converge to `community owner = Governor's Timelock = community treasury = PCE custody`. In that pattern there is no benefit to splitting the community owner from a separate `RATE_MANAGER` or to keeping a separate `treasuryWallet`.
+2. The split adds storage variables (`treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`), administrative functions (`initializeTreasury` / `setTreasuryWallet` / `grantRateManagerRole` / `revokeRateManagerRole` / `hasRole`), and bytecode to a contract that has been near the Polygon 32 KB limit (see commit `cc07abf`). The cost is real; the benefit was hypothetical.
 
 PIP-12 was cancelled on the Polygon Timelock before its implementation switch executed (cancellation tx: `0xe4ed89b0846ce643b29b528e1e2fbe247a51867235ba88cf1760fd944661e1fb` on 2026-04-26). This proposal redesigns the same economic mechanism in the simplest form that meets the actual requirement.
 

--- a/PIPs/pip-16.md
+++ b/PIPs/pip-16.md
@@ -13,20 +13,20 @@ replaces: [12]
 
 ### Abstract
 
-This proposal supersedes PIP-12 with a simplified design. It introduces token value increase and token split operations on PCECommunityToken that adjust the swap rate (`exchangeRate`), gated by `onlyOwner`. The dedicated `RATE_MANAGER_ROLE` and `treasuryWallet` storage proposed in PIP-12 are removed; PCE reserves are pulled from `msg.sender` (i.e. the contract owner). Communities that want to govern these operations on Tally simply transfer ownership to a Governor + Timelock setup, which makes the Timelock both the operation authority and the on-chain treasury (this is the standard Tally Treasury pattern).
+This proposal supersedes PIP-12 with a simplified design. It introduces token value increase and token split operations on PCECommunityToken that adjust the swap rate (`exchangeRate`), gated by `onlyOwner`. The dedicated `RATE_MANAGER_ROLE` and `treasuryWallet` storage proposed in PIP-12 are removed; PCE reserves are pulled from the community owner. Communities that want to govern these operations through a DAO simply transfer ownership to a Governor + Timelock setup, which makes the Timelock both the operation authority and the on-chain treasury for the community.
 
 ### Motivation
 
-PIP-12 introduced a `RATE_MANAGER_ROLE` with a custom mapping-based role system and a separate `treasuryWallet` address, motivated by the assumption that operation authority and PCE custody could live at different addresses, and that owner authority needed to be split off. Subsequent design review revealed that:
+PIP-12 introduced a `RATE_MANAGER_ROLE` with a custom mapping-based role system and a separate `treasuryWallet` address, motivated by the assumption that operation authority and PCE custody could live at different addresses, and that the community owner authority needed to be split off. Subsequent design review revealed that:
 
-1. PCECommunityToken's `owner` is set to the community creator at `createToken` time (not the protocol owner). It is community-scoped from the start.
-2. Communities that govern these operations through Tally inevitably converge to `owner = Governor's Timelock = Tally Treasury = PCE custody`. In that pattern there is no benefit to splitting `owner` from `RATE_MANAGER` or to keeping a separate `treasuryWallet`.
+1. PCECommunityToken's community owner is set at `createToken` time (the address that created the community). It is community-scoped from the start and is unrelated to any protocol-level owner.
+2. Communities that govern these operations through a DAO inevitably converge to `community owner = Governor's Timelock = community treasury = PCE custody`. In that pattern there is no benefit to splitting the community owner from a separate `RATE_MANAGER` or to keeping a separate `treasuryWallet`.
 3. The split adds storage variables (`treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`), administrative functions (`initializeTreasury` / `setTreasuryWallet` / `grantRateManagerRole` / `revokeRateManagerRole` / `hasRole`), and bytecode to a contract that has been near the Polygon 32 KB limit (see commit `cc07abf`). The cost is real; the benefit was hypothetical.
 
 PIP-12 was cancelled on the Polygon Timelock before its implementation switch executed (cancellation tx: `0xe4ed89b0846ce643b29b528e1e2fbe247a51867235ba88cf1760fd944661e1fb` on 2026-04-26). This proposal redesigns the same economic mechanism in the simplest form that meets the actual requirement.
 
 This proposal enables:
-- Community operators (or, after `transferOwnership`, the community's Governor + Timelock) to add PCE reserves to increase token value
+- The community owner (or, after `transferOwnership`, the community's Governor + Timelock) to add PCE reserves to increase token value
 - The same authority to expand token supply via proportional distribution to all holders (token split)
 - Adjustment of the swap rate through reserve management and supply expansion
 
@@ -51,7 +51,7 @@ Both functions are gated by `onlyOwner`. No new role-management functions are in
 function addReserve(address communityToken, uint256 pceAmount) external;
 ```
 
-The caller (the PCECommunityToken contract) MUST forward `msg.sender` of the original `increaseTokenValue` call as the source of PCE via `transferFrom`. Implementations can pass this address as an additional parameter or have PCECommunityToken pull PCE from its caller and transfer it to PCEToken in a single internal step. The exact internal interface is left to the implementation provided that the externally observable behaviour matches this specification.
+`addReserve` MUST be called only by the registered PCECommunityToken contract. PCE is pulled from the community owner (the address returned by `OwnableUpgradeable(communityToken).owner()`) via the standing approval that the community owner has granted to the PCEToken contract.
 
 #### Storage
 
@@ -76,10 +76,10 @@ The PIP-12 events `TreasuryWalletSet`, `RateManagerRoleGranted`, and `RateManage
 
 #### Token Value Increase
 
-Transfers PCE from the caller (the contract owner) to the PCEToken contract and adjusts the swap rate downward, increasing the per-token PCE value of every existing holder.
+Transfers PCE from the community owner to the PCEToken contract and adjusts the swap rate downward, increasing the per-token PCE value of every existing holder.
 
-1. The caller (i.e. the owner of the PCECommunityToken) MUST have approved at least `pceAmount` of PCE to the PCEToken contract in advance.
-2. Transfer `pceAmount` of PCE from the caller to the PCEToken contract via `transferFrom`.
+1. The community owner MUST have approved at least `pceAmount` of PCE to the PCEToken contract in advance.
+2. Transfer `pceAmount` of PCE from the community owner to the PCEToken contract via the standing approval (the PCEToken contract pulls the PCE internally; no separate `transferFrom` call from the caller is required).
 3. Increase `depositedPCEToken` by `pceAmount`.
 4. Adjust `exchangeRate`: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`.
 5. No community tokens are minted.
@@ -103,7 +103,7 @@ The display balance computation incorporates the rebase factor: `displayBalance 
 
 | | Token Value Increase | Token Split |
 |---|---|---|
-| PCE flow | caller → PCEToken contract | none |
+| PCE flow | community owner → PCEToken contract | none |
 | `depositedPCEToken` | increased | unchanged |
 | `exchangeRate` | adjusted down (token value ↑) | adjusted up (token value ↓) |
 | Token supply | unchanged | increased (via rebase factor) |
@@ -114,17 +114,17 @@ The display balance computation incorporates the rebase factor: `displayBalance 
 
 Both operations are gated by `onlyOwner`. There is no separate role:
 
-- For self-managed communities, the `owner` is the community creator's EOA (the address that called `createToken`); they call these functions directly.
-- For governance-managed communities, the community deploys an OZ Governor + TimelockController and calls `transferOwnership(timelock)`. Tally renders the Timelock as the DAO Treasury; PCE held by the Timelock is what feeds `increaseTokenValue`. Proposals are batched: `approve(PCEToken, amount)` from the Timelock + `increaseTokenValue(amount)` in the same batch.
+- For self-managed communities, the community owner is the address that called `createToken` (typically an EOA or multisig); the community owner calls these functions directly.
+- For DAO-managed communities, the community deploys a Governor + TimelockController and calls `transferOwnership(timelock)`. The community's Timelock then becomes the operation authority and the on-chain treasury that holds PCE for `increaseTokenValue`. Proposals are batched: `approve(PCEToken, amount)` from the Timelock + `increaseTokenValue(amount)` in the same batch.
 - Migration between the two modes is performed via standard `transferOwnership`. No PIP-specific migration step is required.
 
 ### Rationale
 
 **Why `onlyOwner` instead of a dedicated role?**
-The `owner` of PCECommunityToken is already community-scoped (assigned at `createToken` to the creator). Communities that need governance simply set `owner` to a Governor's Timelock; communities that operate informally keep `owner` on a multisig or EOA. A separate `RATE_MANAGER_ROLE` is only beneficial if `owner` and the rate-changing authority are intended to live at different addresses, which has no concrete operational use case. Aligning all governable operations (`setTokenSettings`, `increaseTokenValue`, `splitToken`) under the same authority keeps the mental model and the Tally proposal flow coherent.
+The community owner of PCECommunityToken is already community-scoped (assigned at `createToken` to the creator). Communities that need governance simply set the community owner to a Governor's Timelock; communities that operate informally keep the community owner on a multisig or EOA. A separate `RATE_MANAGER_ROLE` is only beneficial if the community owner and the rate-changing authority are intended to live at different addresses, which has no concrete operational use case. Aligning all governable operations (`setTokenSettings`, `increaseTokenValue`, `splitToken`) under the same authority keeps the mental model and the DAO proposal flow coherent.
 
 **Why no `treasuryWallet`?**
-The PCE used for token value increases is held wherever the community's PCE custody lives. When governance is on Tally, that is the Timelock, which is also the caller of `increaseTokenValue`, so `msg.sender` is the correct and only address to pull PCE from. A separate `treasuryWallet` would only matter if the rate-changing authority and the PCE custodian were intentionally different addresses; in practice they are not. Removing the slot also removes the management surface (`initializeTreasury`, `setTreasuryWallet`).
+The PCE used for token value increases is held wherever the community's PCE custody lives. When the community owner is a DAO Timelock, that Timelock is also the caller of `increaseTokenValue`, so the community owner is the correct and only address to pull PCE from. A separate `treasuryWallet` would only matter if the rate-changing authority and the PCE custodian were intentionally different addresses; in practice they are not. Removing the slot also removes the management surface (`initializeTreasury`, `setTreasuryWallet`).
 
 **Why use a factor-based rebase rather than iterating holders?**
 Iterating all holders on-chain is gas-prohibitive and would require maintaining an enumerable holder set. A factor-based approach achieves O(1) gas regardless of holder count and is consistent with PCECommunityToken's existing demurrage factor pattern.
@@ -139,7 +139,7 @@ PCE withdrawal to a treasury would deplete the reserves backing the community to
 | | PIP-12 | PIP-16 (this) |
 |---|---|---|
 | Authority for value ops | dedicated `RATE_MANAGER_ROLE` | `onlyOwner` |
-| PCE source | `treasuryWallet` (separate slot) | `msg.sender` (i.e. owner) |
+| PCE source | `treasuryWallet` (separate slot) | community owner |
 | Storage added (`PCECommunityToken`) | `treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`, `rebaseFactor` | `rebaseFactor` only |
 | Admin functions added | `initializeTreasury`, `setTreasuryWallet`, `grantRateManagerRole`, `revokeRateManagerRole`, `hasRole` | none |
 | Events added | 5 | 2 |
@@ -150,7 +150,7 @@ PCE withdrawal to a treasury would deplete the reserves backing the community to
 
 All changes are additive: new functions, one new storage variable (`rebaseFactor`) appended to existing storage, two new events. Existing function signatures and behaviour are unchanged.
 
-PIP-12 was cancelled on the Polygon Timelock before its Beacon implementation switch executed, so its proposed storage layout (`treasuryWallet`, `_roles`) was never committed on Production or DEV. PIP-16 therefore starts from the current v15 storage layout with no conflicts.
+PIP-12 was cancelled on the Polygon Timelock before its Beacon implementation switch executed, so its proposed storage layout (`treasuryWallet`, `_roles`) was never committed on Production. PIP-16 therefore starts from the current production storage layout with no conflicts.
 
 `rebaseFactor` is treated as `INITIAL_FACTOR` (1e18) when zero, so PCECommunityTokens that have never been split continue to compute display balances identically to before the upgrade.
 
@@ -160,7 +160,7 @@ All examples use `INITIAL_FACTOR = 10^18`.
 
 **Case 1: Token value increase**
 - Initial: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`
-- Owner has approved 50e18 PCE to PCEToken
+- Community owner has approved 50e18 PCE to PCEToken
 - Operation: `increaseTokenValue(50e18)`
 - Result: `depositedPCEToken = 150e18`, `exchangeRate = 1e18 * 100e18 / 150e18 ≈ 0.667e18`
 - Effect: Per-token PCE value of every holder increases.
@@ -181,27 +181,27 @@ All examples use `INITIAL_FACTOR = 10^18`.
 - Result: revert (`Ownable: caller is not the owner`)
 
 **Case 5: Insufficient approval**
-- Owner has approved 0 PCE to PCEToken
+- Community owner has approved 0 PCE to PCEToken
 - Operation: `increaseTokenValue(10e18)`
 - Result: revert (`ERC20InsufficientAllowance` from PCEToken)
 
-**Case 6: Governance flow (Tally)**
-- Owner of the PCECommunityToken is a Polygon TimelockController.
-- A Governor proposal batches: (a) `PCEToken.approve(communityToken, amount)` from the Timelock, (b) `communityToken.increaseTokenValue(amount)`.
-- Both calls execute as `msg.sender = Timelock`.
-- Result: PCE leaves the Timelock (Tally Treasury) and is added to the reserves; `exchangeRate` adjusts.
+**Case 6: DAO governance flow**
+- Community owner of the PCECommunityToken is a TimelockController.
+- A Governor proposal batches: (a) `PCEToken.approve(PCEToken, amount)` from the Timelock, (b) `communityToken.increaseTokenValue(amount)`.
+- Both calls execute under the Timelock as the community owner.
+- Result: PCE leaves the Timelock (the community's on-chain treasury) and is added to the reserves; `exchangeRate` adjusts.
 
 ### Security Considerations
 
-**Compromise of the owner.** A compromised owner can call `splitToken` repeatedly to dilute the per-token PCE value, or can drain its own approved PCE via `increaseTokenValue`. PCE never leaves the system as a result of `splitToken`, so the attack surface for value-extraction is bounded by the owner's own PCE balance and approval. Communities SHOULD use a multisig or DAO Governor + Timelock for the owner role. The governance model is out of scope for this proposal.
+**Compromise of the community owner.** A compromised community owner can call `splitToken` repeatedly to dilute the per-token PCE value, or can drain its own approved PCE via `increaseTokenValue`. PCE never leaves the system as a result of `splitToken`, so the attack surface for value-extraction is bounded by the community owner's own PCE balance and approval. Communities SHOULD use a multisig or DAO Governor + Timelock for the community owner role. The governance model is out of scope for this proposal.
 
 **Front-running.** A user MAY attempt to front-run a pending `splitToken` transaction with a `swapFromLocalToken` at the pre-split rate. Because no PCE leaves reserves on a split, the impact is limited to rate arbitrage. Mitigation strategies (commit-reveal, private mempools, etc.) are out of scope.
 
-**Reentrancy.** `increaseTokenValue` performs an external call (`transferFrom`). `splitToken` is purely internal (factor adjustment, no external calls). Implementations MUST either follow the checks-effects-interactions pattern or use a reentrancy guard for `increaseTokenValue`.
+**Reentrancy.** `increaseTokenValue` performs an external call (the internal pull from the community owner). `splitToken` is purely internal (factor adjustment, no external calls). Implementations MUST either follow the checks-effects-interactions pattern or use a reentrancy guard for `increaseTokenValue`.
 
 **Integer overflow / underflow.** Rate computations multiply before dividing. Implementations MUST use `Math.mulDiv` or equivalent safe-math primitives to prevent precision loss and overflow.
 
-**Approval grant requirement.** `increaseTokenValue` relies on a prior `approve` from the owner. In the Tally / Timelock flow this is provided by including the `approve` call in the same proposal batch as `increaseTokenValue`, which guarantees atomicity within the batch executor.
+**Approval grant requirement.** `increaseTokenValue` relies on a prior `approve` from the community owner. In the DAO / Timelock flow this is provided by including the `approve` call in the same proposal batch as `increaseTokenValue`, which guarantees atomicity within the batch executor.
 
 ### Notes
 

--- a/PIPs/pip-16.md
+++ b/PIPs/pip-16.md
@@ -51,7 +51,9 @@ Both functions are gated by `onlyOwner`. No new role-management functions are in
 function addReserve(address communityToken, uint256 pceAmount) external;
 ```
 
-`addReserve` MUST be called only by the registered PCECommunityToken contract. PCE is pulled from the community owner (the address returned by `OwnableUpgradeable(communityToken).owner()`) via the standing approval that the community owner has granted to the PCEToken contract.
+`addReserve` MUST be called only by the registered PCECommunityToken contract (enforced by `require(msg.sender == communityToken)` and `localTokens[communityToken].isExists`). PCE is pulled from the community owner (the address returned by `OwnableUpgradeable(communityToken).owner()`) via the standing approval that the community owner has granted to the PCEToken contract.
+
+**Note: `addReserve` is not a client-facing entrypoint.** It is an internal coordination function between the two contracts: PCECommunityToken's `increaseTokenValue` calls `addReserve` to atomically update `depositedPCEToken` accounting (which lives on PCEToken), pull PCE from the community owner (using PCEToken's own ERC20 internals), and adjust `exchangeRate`. Clients (community owners, multisigs, Timelocks, etc.) interact only with `PCECommunityToken.increaseTokenValue` and `PCECommunityToken.splitToken`. A direct call to `addReserve` from any address other than the registered PCECommunityToken contract reverts. This pattern follows the same convention as the existing `PCECommunityToken.mint` / `PCECommunityToken.recordSwapToPCE` functions, which are similarly gated to only accept calls from PCEToken.
 
 #### Storage
 


### PR DESCRIPTION
## Summary

- Add PIP-16: Owner-controlled Token Value Operations (supersedes PIP-12)
- **PIP full text**: [PIPs/pip-16.md](https://github.com/peacecoin-protocol/PIPs/blob/pip-16/PIPs/pip-16.md)
- Implementation: peacecoin-protocol/core PR (TBD, branch `feature/pip-16-token-value-ops`)
- PIP-12 cancellation tx (Polygon): `0xe4ed89b0846ce643b29b528e1e2fbe247a51867235ba88cf1760fd944661e1fb`

## Abstract

This proposal supersedes PIP-12 with a simplified design. It adds two operations that adjust the swap rate (`exchangeRate`) of a community token: `increaseTokenValue` and `splitToken`. Both live on the PCEToken contract — the same contract that already hosts the swap operations between PCE and community tokens — and are gated to the community owner. The dedicated `RATE_MANAGER_ROLE` and `treasuryWallet` storage proposed in PIP-12 are removed; PCE reserves are pulled directly from the caller (the community owner). Communities that want to govern these operations through a DAO simply transfer ownership of their community token to a Governor + Timelock setup, which makes the Timelock both the operation authority and the on-chain treasury for the community.

### Key Points

- **Operations on PCEToken**: `increaseTokenValue(communityToken, amount)` / `splitToken(communityToken, amount)` live next to the existing `swapFromLocalToken` / `swapToLocalToken` / `swapFeeFromLocalToken` and the `depositedPCEToken` / `exchangeRate` state they mutate
- **Community-owner auth via direct check**: `require(msg.sender == OwnableUpgradeable(communityToken).owner())` — no separate role
- **No `treasuryWallet` and no prior `approve`**: PCE is pulled from `msg.sender` (the verified community owner) using PCEToken's own internal `_transfer`, matching the existing swap-flow pattern
- **`applyRebase` is the only addition to PCECommunityToken**: gated to PCEToken, follows the same privileged-callback pattern as existing `mint` / `burnByPCEToken` / `recordSwapToPCE`
- **rebaseFactor preserved**: Token splits still use a factor-based rebase for O(1) gas cost
- **DAO governance alignment**: Communities transfer ownership to their own Governor's Timelock; the same Timelock holds the community's PCE custody, so operation authority and PCE custody converge naturally
- **Storage layout**: PIP-12's `treasuryWallet` and `_roles` slots are retained as `__deprecated_*` (private) on PCECommunityToken to preserve layout compatibility with environments that already executed PIP-12 directly, validated against both v15 (DEV baseline) and v13 (Production baseline) via OpenZeppelin upgrades-core
- **Asymmetric by design (unchanged from PIP-12)**: Token value increase adds PCE; token split rebases supply without withdrawing PCE — prevents bypassing daily swap limits
- **Bytecode**: PCECommunityToken shrinks by ~1.5 KB vs PIP-12 (admin functions removed and operations consolidated to PCEToken)

### Changes vs PIP-12

| | PIP-12 | PIP-16 |
|---|---|---|
| Authority | `RATE_MANAGER_ROLE` (mapping-based) | community owner check on PCEToken |
| Operation host contract | PCECommunityToken | PCEToken |
| Cross-contract round-trip | `community → addReserve → community` | none (PCEToken handles directly) |
| PCE source | `treasuryWallet` (separate slot) | community owner (= caller of PCEToken) |
| Standing `approve` from caller | required | not required |
| New storage on community token | `treasuryWallet`, `_roles`, `rebaseFactor` | `rebaseFactor` only |
| Admin functions on community token | 5 (initializeTreasury, setTreasuryWallet, grant/revokeRateManagerRole, hasRole) | 0 |
| New internal-coordination on community token | n/a | `applyRebase` (one) |
| DAO governance migration | grant role + set treasury | `transferOwnership` (already supported) |

### Background

PIP-12 was approved on-chain and reached the Polygon Timelock queue, but the Beacon implementation switch was cancelled before execution after a design review. The cancellation was performed via `GovernanceReceiver.cancelScheduledBatch` (cancellation tx `0xe4ed89b0...`), which leaves the Production storage layout in its pre-PIP-12 state.

DEV had already been upgraded directly to a v15 implementation (which contained the PIP-12 storage layout). PIP-16 retains the PIP-12 slots as `__deprecated_*` so a single v16 implementation upgrades cleanly from both states (DEV and Production).

PIP-12 will be marked `Withdrawn` in a follow-up PR.

---

<details><summary>日本語版 PIP 全文</summary>

```
---
pip: 16
title: Owner-controlled Token Value Operations (supersedes PIP-12)
proposer: CHIBA Masahiro (@nihen)
status: Draft
type: Core
created: 2026-04-26
requires: []
replaces: [12]
---
```

## PIP-16: コミュニティオーナー権限ベースのトークン価値操作（PIP-12 を置換）

### Abstract（要約）

本提案は PIP-12 を置換し、より簡素な設計を導入する。コミュニティトークンのスワップレート（`exchangeRate`）を調整する 2 つの操作 `increaseTokenValue` と `splitToken` を追加する。両関数は **PCEToken コントラクト**（既に PCE ↔ コミュニティトークン間のスワップ操作を持つコントラクト）に配置し、コミュニティオーナー（PCECommunityToken の owner）を権限主体とする。PIP-12 で導入予定だった `RATE_MANAGER_ROLE` と `treasuryWallet` ストレージは削除し、PCE 準備金は呼び出し元（コミュニティオーナー）から直接吸い上げる。DAO でガバナンスする運用では、コミュニティがコミュニティトークンの所有権を Governor + Timelock 構成に `transferOwnership` するだけで、Timelock が同時に「操作権限の主体」「コミュニティの PCE 金庫」となる。

### Motivation

PIP-12 では「操作権限の保持アドレス」と「PCE 保管アドレス」を別々に持てるよう、独自マッピングベースの `RATE_MANAGER_ROLE` と `treasuryWallet` ストレージを設計に組み込んだ。設計レビューの結果、以下が明らかになった:

1. DAO でガバナンスする運用ではコミュニティオーナー = Governor の Timelock = コミュニティの金庫 = PCE 保管アドレスに必然的に集約される。この前提ではコミュニティオーナーと別ロールに分離する利点も `treasuryWallet` の独立も**実運用上の利点がない**。
2. 分離設計は PCECommunityToken にストレージ変数（`treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`）と管理関数（`initializeTreasury` / `setTreasuryWallet` / `grantRateManagerRole` / `revokeRateManagerRole` / `hasRole`）を増やし、Polygon の 32 KB バイトコード制限が逼迫しているコントラクト（直近のリファクタコミット `cc07abf` 参照）を更に圧迫する。コストは実在し、利点は仮説段階のままだった。

PIP-12 は Polygon Timelock 上で Beacon の implementation 切替が実行される前にキャンセルされた（キャンセル tx: `0xe4ed89b0846ce643b29b528e1e2fbe247a51867235ba88cf1760fd944661e1fb`、2026-04-26）。本提案は同じ経済機能を、実際の要件を満たす最小構成で再設計する。

本提案により:
- コミュニティオーナー（または `transferOwnership` 後はコミュニティの Governor + Timelock）が PCE 準備金を追加してトークン価値を上げる（増価）
- 同じ権限主体がリベース方式で全ホルダーに按分配布する形でトークン供給量を拡大する（トークン分割）
- 準備金管理と供給量拡大によりスワップレートを調整する

### Specification

#### インターフェース

新たな関数は **PCEToken** に追加する。PCECommunityToken には内部協調用の `applyRebase` を 1 つだけ追加する。

**PCEToken — 新関数:**

```solidity
function increaseTokenValue(address communityToken, uint256 pceAmount) external;
function splitToken(address communityToken, uint256 mintAmount) external;
```

両関数は `OwnableUpgradeable(communityToken).owner() == msg.sender` で呼び出し元がコミュニティオーナーであることを検証する。コミュニティトークンは `localTokens[communityToken].isExists == true` で登録済みである必要がある。

**PCECommunityToken — 新関数:**

```solidity
function applyRebase(uint256 newFactor) external;
```

`applyRebase` は `msg.sender == pceAddress`（= PCEToken のみ）にゲートされる。これは `splitToken` 中に PCEToken がコミュニティトークンの `rebaseFactor` を更新するための内部協調用関数で、クライアントが直接呼ぶエントリポイントではない。既存の `mint` / `burnByPCEToken` / `recordSwapToPCE`（同様に PCEToken のみから呼べるよう gate されている）と同じ慣習に従う。クライアント（コミュニティオーナー、マルチシグ、Timelock 等）が触るのは `PCEToken.increaseTokenValue` と `PCEToken.splitToken` のみ。

#### ストレージ

`PCECommunityToken` に以下のストレージ変数を追加する:

```solidity
uint256 public rebaseFactor; // 遅延初期化。0 の場合は INITIAL_FACTOR (1e18) として扱う
```

すべての新変数は既存ストレージの末尾に追加する（MUST）。既存のストレージスロットは変更しない（MUST NOT）。

PIP-12 は `treasuryWallet` と `_roles` mapping を導入していた。PIP-12 の Beacon implementation 切替は Production では実行されなかったが、DEV では直接 v15 implementation にアップグレード済みでこれらのスロットがコミットされている。単一の v16 implementation で DEV と Production の両方をクリーンにアップグレードできるよう、v16 では PIP-12 の元のスロット位置に `__deprecated_treasuryWallet` と `__deprecated_roles` を private プレースホルダーとして配置する（OpenZeppelin upgrade-safety 検証のため `@custom:oz-renamed-from` annotation 付き）。PIP-16 のロジックでは使用しない。

PCEToken にはストレージ追加なし。

#### イベント

```solidity
event TokenValueIncreased(
    address indexed communityToken,
    uint256 pceAmount,
    uint256 oldExchangeRate,
    uint256 newExchangeRate
);
event TokenSplit(
    address indexed communityToken,
    uint256 mintAmount,
    uint256 oldExchangeRate,
    uint256 newExchangeRate,
    uint256 oldRebaseFactor,
    uint256 newRebaseFactor
);
```

両イベントは PCEToken から発行される。`communityToken` indexed フィールドにより、どのコミュニティに対する操作かを識別できる。PIP-12 のイベント `TreasuryWalletSet`, `RateManagerRoleGranted`, `RateManagerRoleRevoked` は削除する。

#### 増価（Token Value Increase）

コミュニティオーナーから PCEToken コントラクトへ PCE を直接送金し、スワップレートを下方調整する。既存ホルダーのトークン1枚あたりの PCE 換算価値が上がる。

1. `localTokens[communityToken].isExists == true` および `OwnableUpgradeable(communityToken).owner() == msg.sender` を検証する。
2. PCEToken のグローバルなデマレージファクターを更新する（`updateFactorIfNeeded()`）。`transfer` / `transferFrom` / `swapFromLocalToken` 等の他の token 移動エントリポイントと整合性を保つため。
3. PCEToken のコントラクト内 `_transfer` を用いて `msg.sender` から PCEToken コントラクトへ `pceAmount` の PCE を送金する。事前 `approve` は不要（PCEToken は PCE ERC20 自身で、呼び出し元はコミュニティオーナーであることが検証済みのため）。
4. `depositedPCEToken` を `pceAmount` 増加。
5. `exchangeRate` を調整:
   - `oldDeposited == 0` の場合: `newRate = oldRate` を維持する。比例公式では reserve 枯渇時に rate が 0 になり、以降のすべての swap が壊れるため、直前のレートを保持することで枯渇状態からのリカバリを可能にする。
   - それ以外の場合: `newRate = oldRate * oldDeposited / (oldDeposited + pceAmount)`。
6. コミュニティトークンのミントなし。
7. `TokenValueIncreased(communityToken, pceAmount, oldRate, newRate)` を発行。

#### トークン分割（Token Split）

リベースファクターを調整することで新しいコミュニティトークンを発行し、全既存ホルダーに保有比率に応じて按分配布する。PCE 準備金からの引き出しは行わない。トークン供給量の増加を反映してスワップレートを上方調整し、トークン1枚あたりの PCE 換算価値を下げる。

1. `localTokens[communityToken].isExists == true`、`OwnableUpgradeable(communityToken).owner() == msg.sender`、コミュニティトークンの現在の `totalSupply()` が 0 より大きいことを検証する。
2. PCEToken のグローバルなデマレージファクターを更新する（`updateFactorIfNeeded()`）。Token Value Increase と同様、他のエントリポイントとの整合性のため。
3. `mintAmount` はコミュニティトークンの表示単位（リベース後の単位）で指定。
4. `newRebaseFactor = oldRebaseFactor * (totalDisplaySupply + mintAmount) / totalDisplaySupply` を計算する（`oldRebaseFactor` が 0 の場合は `INITIAL_FACTOR` として扱う。これにより分割が一度も行われていないコミュニティの初回分割が正しく動作する）。
5. PCEToken からコミュニティトークンの `applyRebase(newRebaseFactor)` を呼び、新しいファクターをコミットする。
6. コミュニティトークンの `balanceOf` / `totalSupply` 計算が `rebaseFactor` を反映するため、全ホルダーの表示残高が按分で増加する。
7. `exchangeRate` を調整: `newRate = oldRate * newRebaseFactor / oldRebaseFactor`。
8. `depositedPCEToken` は変更なし。
9. PCE の移動なし。
10. `TokenSplit(communityToken, mintAmount, oldRate, newRate, oldRebaseFactor, newRebaseFactor)` を発行。

表示残高の計算にリベースファクターを組み込む: `displayBalance = rawBalance * INITIAL_FACTOR / getCurrentFactor() * rebaseFactor / INITIAL_FACTOR`（`rebaseFactor` は 0 の場合 `INITIAL_FACTOR` として扱うため、分割が一度も行われていないトークンはアップグレード前と同一の表示残高となる）

#### 対称性

| | 増価 | トークン分割 |
|---|---|---|
| PCE 移動 | コミュニティオーナー → PCEToken コントラクト | なし |
| `depositedPCEToken` | 増加 | 変更なし |
| `exchangeRate` | 下方調整（トークン価値↑） | 上方調整（トークン価値↓） |
| トークン供給量 | 変更なし | 増加（リベースファクター経由） |
| `rebaseFactor` | 変更なし | 増加 |
| ホルダー残高 | 変更なし | 全員が按分で増加 |

#### 権限

両操作は `OwnableUpgradeable(communityToken).owner() == msg.sender` でゲートされる。別ロールは存在しない。

- 自己管理型コミュニティ: コミュニティオーナーは `createToken` を呼んだアドレス（典型的には EOA またはマルチシグ）。コミュニティオーナーが PCEToken を直接呼び出す。
- DAO 管理型コミュニティ: コミュニティが Governor + TimelockController をデプロイし、コミュニティトークンに対して `transferOwnership(timelock)` を実行する。コミュニティの Timelock が操作権限の主体兼 PCE 金庫となり、`increaseTokenValue` の原資となる。提案は単一 call `PCEToken.increaseTokenValue(communityToken, amount)` で済む。Timelock が呼び出し元となり PCEToken が `msg.sender` から PCE を吸い上げるため、事前 `approve` は不要。
- 両モード間の移行はコミュニティトークンに対する標準の `transferOwnership` で行う。本 PIP 固有の移行手順はない。

### Rationale（設計根拠）

**なぜ PCECommunityToken ではなく PCEToken に置くのか？**
これらの操作で変更されるステート — `localTokens[communityToken].depositedPCEToken` と `.exchangeRate` — は PCEToken に存在し、既存のスワップ関数（`swapFromLocalToken`, `swapToLocalToken`, `swapFeeFromLocalToken`）と同じ場所にある。新操作をステートと関連スワップロジックの隣に配置することで、PCE↔コミュニティ間の経済操作のための単一の coherent な surface が実現できる。また既存の「PCEToken がコミュニティトークンに privileged に call back する」プロトコルパターン（`mint`, `burnByPCEToken`, `recordSwapToPCE`）と整合する。`applyRebase` は同パターンの新規エントリ。PIP-12 で当初これらをコミュニティトークン側に配置していたのは、設計が「コミュニティ単位のトレジャリーウォレット + ロールシステム」を中心に組まれていたため。これらの概念を削除した今、コミュニティトークン側に置く理由は失われている。PCEToken に集約することで、`addReserve` のクロスコントラクト往復を排除し、事前 `approve` 要件をなくし、コミュニティトークンのバイトコードを削減できる（Polygon の 32 KB 上限に対する余裕が増える）。

**なぜ専用ロールではなく `onlyOwner` 相当の権限か？**
PCECommunityToken のコミュニティオーナーは既にコミュニティスコープ（`createToken` 時に作成者へ割当）である。ガバナンスを必要とするコミュニティはコミュニティオーナーを Governor の Timelock に設定するだけでよく、非公式に運営するコミュニティは EOA やマルチシグにコミュニティオーナーを残すだけでよい。`RATE_MANAGER_ROLE` の分離が意味を持つのは「コミュニティオーナーとレート操作権限を意図的に別アドレスに置きたい」具体的な運用ケースが存在する場合のみであり、それは現実的に存在しない。すべてのガバナンス対象操作を同じ権限主体に統一することで、メンタルモデルと DAO 提案フローを一貫させられる。

**なぜ `treasuryWallet` を持たないか？**
増価で使う PCE はコミュニティの PCE 保管場所そのもの。コミュニティオーナーが DAO Timelock の場合、その Timelock が `increaseTokenValue` の呼び出し元でもあり、コミュニティオーナーが PCE の出所として正しく、唯一のアドレスとなる。`treasuryWallet` の独立が意味を持つのは、レート操作権限と PCE 保管者を意図的に異なるアドレスに置く運用が存在する場合のみであり、現実にはそのようなケースはない。

**なぜコミュニティオーナーからの事前 `approve` が不要か？**
PCEToken は PCE ERC20 コントラクト自身。コミュニティオーナーが `PCEToken.increaseTokenValue(...)` を直接呼ぶと、その call は PCEToken 自身の所有権コンテキストを通る。PCEToken はコントラクト内 `_transfer(msg.sender, address(this), pceAmount)` を直接使え、外部 `transferFrom` のラウンドトリップが不要になる。これは既存の `swapFromLocalToken` / `swapToLocalToken` と同じパターンで、ユーザーが `approve` を発行する必要なく PCE が出入りする仕組み。

**なぜホルダーを反復処理するのではなくファクターベースのリベースを使うのか？**
オンチェーンで全トークンホルダーを反復処理するのはガスコストが高すぎ、列挙可能なホルダーセットの維持も必要になる。ファクターベース方式はホルダー数に関係なく O(1) のガスコストで実現でき、PCECommunityToken の既存デマレージファクターパターンと一貫している。

**なぜ増価では `exchangeRate` を調整するのか？**
ミントは既存保有者を希薄化する。`exchangeRate` の調整は、トークン残高や総供給量に影響を与えず、すべてのコミュニティトークンの PCE 換算価値を均一に変更できる。

**なぜトークン分割で PCE 引き出しではなくリベース方式の配布を使うのか？**
トレジャリーへの PCE 引き出しはコミュニティトークンを裏付ける準備金を枯渇させる。リベース方式は PCE 準備金をそのまま維持し、代わりにトークン供給量を按分で拡大する。システムから価値が流出せず、経済的効果は均一な供給量拡大（株式分割に類似）となり、各ホルダーの持分比率を維持しつつトークン1枚あたりの価値を調整する。

**PIP-12 との比較**

| | PIP-12 | PIP-16（本提案） |
|---|---|---|
| 価値操作の権限主体 | 専用 `RATE_MANAGER_ROLE`（mapping ベース） | PCEToken でのコミュニティオーナー検証 |
| 操作配置先 | PCECommunityToken | PCEToken |
| クロスコントラクト往復 | `community → addReserve → community` | なし（PCEToken が直接処理） |
| PCE の出所 | `treasuryWallet`（独立スロット） | コミュニティオーナー（= PCEToken の呼び出し元） |
| 呼び出し元の事前 `approve` | 必要 | 不要 |
| ストレージ追加（`PCECommunityToken`） | `treasuryWallet`, `_roles`, `RATE_MANAGER_ROLE`, `rebaseFactor` | `rebaseFactor` のみ |
| 管理関数の追加 | `initializeTreasury`, `setTreasuryWallet`, `grantRateManagerRole`, `revokeRateManagerRole`, `hasRole` | なし |
| イベントの追加 | 5（コントラクト分散） | 2（両方 PCEToken、`communityToken` indexed） |
| DAO ガバナンスへの移行手順 | ロール付与 + treasury 設定 | `transferOwnership`（既存機能） |
| バイトコードへの影響（コミュニティトークン） | 大（Polygon 32 KB 制限が逼迫している現状で問題） | PIP-12 比で約 1.5 KB 削減 |

### Backwards Compatibility（後方互換性）

すべての変更は追加的: PCEToken に新関数、PCECommunityToken に内部協調関数 1 個（`applyRebase`）、新ストレージ変数 1 個（`rebaseFactor`）を既存末尾に追加、新イベント 2 個。既存の関数シグネチャや動作は変更しない。

PIP-12 は Polygon Timelock 上で Beacon implementation 切替が実行される前にキャンセルされており、提案時点のストレージレイアウトは Production には反映されていない。PIP-16 は現状の Production ストレージレイアウトを起点に開始でき、衝突は発生しない。DEV は直接 v15 implementation にアップグレード済みで PIP-12 のスロットがコミットされていたが、v16 ではこれらのスロットを `__deprecated_*` の private プレースホルダーとして残すため、単一の v16 implementation で DEV と Production の両環境をクリーンにアップグレードできる。

`rebaseFactor` は 0 の場合 `INITIAL_FACTOR`（1e18）として扱うため、分割が一度も行われていない PCECommunityToken はアップグレード前と完全に同一の表示残高を計算し続ける。

### Test Cases（テストケース）

すべての例で `INITIAL_FACTOR = 10^18` を使用する。

**ケース 1: 増価**
- 初期状態: `depositedPCEToken = 100e18`, `exchangeRate = 1e18`、コミュニティオーナーは 100e18 PCE を保有
- 操作: コミュニティオーナーが `pceToken.increaseTokenValue(communityToken, 50e18)` を呼ぶ
- 結果: `depositedPCEToken = 150e18`, `exchangeRate = 1e18 * 100e18 / 150e18 ≈ 0.667e18`
- 効果: 全ホルダーのトークン1枚あたり PCE 換算価値が上昇。コミュニティオーナーの PCE 残高が 50e18 減少。

**ケース 2: トークン分割（供給量拡大）**
- 初期状態: `totalDisplaySupply = 200e18`, `exchangeRate = 1e18`, `rebaseFactor = 1e18`
- 操作: コミュニティオーナーが `pceToken.splitToken(communityToken, 50e18)` を呼ぶ
- 結果: `rebaseFactor = 1.25e18`, `exchangeRate = 1.25e18`
- 効果: 全ホルダーの表示残高が25%増加。トークン1枚あたりの PCE 換算価値は減少。`depositedPCEToken` は変更なし。各ホルダーの PCE 換算総価値は変更なし。

**ケース 3: トークン分割は持分比率を維持する**
- 初期状態: Alice 100 (50%), Bob 100 (50%), `totalDisplaySupply = 200e18`
- 操作: `splitToken(communityToken, 100e18)`
- 結果: Alice 150 (50%), Bob 150 (50%), `totalDisplaySupply = 300e18`

**ケース 4: 権限なしアクセス（オーナー以外の呼び出し）**
- コミュニティオーナーでないアカウントが `pceToken.increaseTokenValue(communityToken, 10e18)` または `pceToken.splitToken(communityToken, 10e18)` を呼び出し
- 結果: revert (`Only community owner`)

**ケース 5: applyRebase の権限制御**
- PCEToken 以外から `communityToken.applyRebase(2e18)` を呼び出し
- 結果: revert (`Only PCE token`)

**ケース 6: DAO ガバナンスフロー**
- PCECommunityToken のコミュニティオーナーが TimelockController
- Governor 提案には単一 call: `pceToken.increaseTokenValue(communityToken, amount)` のみ
- `msg.sender = Timelock = OwnableUpgradeable(communityToken).owner()` で実行されるため権限チェックを通過
- 結果: Timelock（コミュニティの金庫）から PCE が出て準備金に追加され、`exchangeRate` が調整される

**ケース 7: 枯渇した reserve からの復帰**
- 初期状態: `depositedPCEToken == 0`（`swapFromLocalToken` / `swapFeeFromLocalToken` 等で reserve が完全に枯渇）、`exchangeRate == R`（正の値）
- 操作: コミュニティオーナーが `pceToken.increaseTokenValue(communityToken, X)` を呼び出し（`X > 0`）
- 結果: `depositedPCEToken == X`、`exchangeRate == R`（fallback 分岐により `oldDeposited == 0` の場合は前値を保持するため変更なし）
- 効果: rate が 0 でないため以降の swap が正常動作する

### Security Considerations（セキュリティ考慮事項）

**コミュニティオーナーの侵害**: 侵害されたコミュニティオーナーは `splitToken` を繰り返し呼び出してトークン1枚あたりの PCE 換算価値を希薄化させたり、自身の PCE を `increaseTokenValue` 経由で吸い上げることが可能。`splitToken` ではシステムから PCE が流出しないため、価値抽出の攻撃面はコミュニティオーナー自身の PCE 残高に限定される。コミュニティはコミュニティオーナーロールにマルチシグまたは DAO Governor + Timelock を使用すべき（SHOULD）。ガバナンスモデルは本提案のスコープ外。

**フロントランニング**: ユーザーがメモリプール内の `splitToken` を `swapFromLocalToken`（分割前のレート）でフロントランする可能性がある。分割では PCE 準備金からの引き出しがないため、影響はレートの裁定取引に限定される。緩和策（commit-reveal、プライベートメモリプール等）は本提案のスコープ外。

**リエントランシー**: `increaseTokenValue` は PCEToken 内の `_transfer` のみを実行（PCEToken からの外部 call なし）。`splitToken` は登録済み PCECommunityToken の `applyRebase` を 1 回呼び出す。PCECommunityToken の集合はガバナンスにより登録された実装に限定されるため、外部 call が任意のコードへリダイレクトされることはない。実装は拡張時には checks-effects-interactions パターンに従うべき（SHOULD）。

**整数オーバーフロー / アンダーフロー**: レート計算式は除算前に乗算を行う。実装は精度損失とオーバーフローを防ぐために `Math.mulDiv` または同等の安全な数学関数を使用しなければならない（MUST）。

**権限チェックの順序**: PCEToken は登録チェック (`isExists`) を所有権チェック (`owner() == msg.sender`) より先に行う。これは、未登録の悪意あるコントラクトが所有権チェックの probe（例: revert）に影響を与えないようにするため重要。実装は登録チェックを必ず先に行わなければならない（MUST）。

### Notes

- **影響範囲**: PCEToken と PCECommunityToken の両コントラクトのアップグレードが必要。実装は既存の UUPS プロキシ / Beacon プロキシの背後に配置される。
- **PIP-12 のステータス**: Polygon Timelock 層で Beacon implementation 切替が実行される前にキャンセル済み。キャンセル tx: `0xe4ed89b0846ce643b29b528e1e2fbe247a51867235ba88cf1760fd944661e1fb`（Polygon, 2026-04-26）。本提案が finalize されたら PIP-12 は `Withdrawn` に更新すべき（SHOULD）。
- **スコープ外**: トレジャリー / 保管方法（マルチシグ、DAO ガバナンス等）は各コミュニティの判断に委ねる。コミュニティの解散は別の提案で対処すべき。
- **依存**: なし（既存の UUPS / Beacon プロキシ構成の上に構築）。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
