### PR TITLE
PIP-17: Deposit Migration on Inter-community Swap

### DIFF
--- a/PIPs/pip-17.md
+++ b/PIPs/pip-17.md
@@ -1,0 +1,248 @@
+---
+pip: 17
+title: Deposit Migration on Inter-community Swap
+proposer: CHIBA Masahiro (@nihen)
+status: Draft
+type: Core
+created: 2026-05-01
+requires: []
+replaces: []
+---
+
+## PIP-17: Deposit Migration on Inter-community Swap
+
+### Abstract
+
+This proposal fixes a long-standing accounting drift in inter-community community-token swaps. Today, when a user calls `PCECommunityToken.swapTokens(toToken, amount)` to swap directly from community A to community B, raw supply moves (burned on A, minted on B) but the per-community PCE reserve accounting in `PCEToken.localTokens[*].depositedPCEToken` does **not** move — even though the corresponding PCE-denominated claim now sits with B's holders. This proposal adds a single PCEToken function, `transferDepositOnInterCommunitySwap`, that is called by the source community token during `swapTokens` to move the PCE-equivalent of the swapped amount from the source community's deposit accounting to the destination community's deposit accounting. After this change, the direct A→B path becomes accounting-equivalent to the existing indirect A→PCE→B path. The per-community reserve model is retained.
+
+### Motivation
+
+`PCEToken` tracks PCE reserves on a per-community basis via `localTokens[community].depositedPCEToken`. Three out of four reserve-affecting flows already maintain this accounting correctly:
+
+- `swapToLocalToken(B, amount)` (PCE → B): increments `localTokens[B].depositedPCEToken` by `amount`.
+- `swapFromLocalToken(A, amount)` (A → PCE): decrements `localTokens[A].depositedPCEToken` by the PCE-equivalent.
+- `swapFeeFromLocalToken(...)` (meta-tx fee path): decrements the source community's deposit by the PCE-equivalent fee.
+
+The fourth — direct community-to-community swap via `PCECommunityToken.swapTokens(toToken, amount)` — does not. It burns raw supply on the source and mints on the destination, but **never touches** `localTokens[fromToken].depositedPCEToken` or `localTokens[toToken].depositedPCEToken`. Over time and across many inter-community swaps, this produces a deposit-vs-claim drift between communities:
+
+- Source community A: holders have already exited (raw supply burned), but PCE reserve accounting still attributes that PCE backing to A.
+- Destination community B: holders now hold the claim (raw supply minted), but PCE reserve accounting attributes no additional backing to B.
+
+The two consequences are:
+
+1. **Per-community swap-back fairness breaks.** When a B holder later calls `swapFromLocalToken(B, ...)` to exit to PCE, the success/failure check (`localTokens[B].depositedPCEToken >= pcetokenAmount`) consults a deposit number that does not reflect the PCE that actually entered B (via inter-community swap). B can fail swap-back even though, in PCE-denominated terms across the protocol, B-attributable deposits should have been there.
+2. **Path equivalence breaks.** A user who needs to move from A's tokens to B's tokens has two paths today: indirect (`swapFromLocalToken(A) → swapToLocalToken(B)`) and direct (`swapTokens(B)`). The two paths produce **different** post-state accounting in `localTokens[*].depositedPCEToken`, even though they are economically intended to be equivalent. This is a footgun for governance, for off-chain accounting, and for any future logic that reads per-community deposit values.
+
+Note: this proposal scope is narrow. It does **not** restructure the per-community reserve model into a global pool (a separate alternative considered and explicitly rejected in favor of preserving per-community accounting). It does not address the orthogonal drifts described in the same design discussion: ARIGATO CREATION mints inflate community-token claims without inflating deposits, and PCE BASE Token decay erodes claims without changing deposits. Those remain per-community properties of the existing reserve model and are out of scope here.
+
+### Specification
+
+#### Interface
+
+A new function is added to **PCEToken**:
+
+```solidity
+function transferDepositOnInterCommunitySwap(
+    address fromToken,
+    address toToken,
+    uint256 fromDisplayAmount
+) external returns (uint256 movedPceAmount);
+```
+
+**Authorization:** the caller MUST be the source community token: `require(msg.sender == fromToken, "Caller must be the from-side community token")`. Both `fromToken` and `toToken` MUST be registered (`localTokens[*].isExists`). `fromToken != toToken` MUST hold.
+
+**Behavior:** the function computes the PCE-equivalent of `fromDisplayAmount` using the source community's exchange rate and current factor, decrements `localTokens[fromToken].depositedPCEToken` by that amount, increments `localTokens[toToken].depositedPCEToken` by the same amount, and emits an event. If the source's recorded deposit is insufficient to cover the PCE-equivalent, the call MUST revert.
+
+**PCECommunityToken.swapTokens — modified behavior:** after the existing burn-on-source / mint-on-destination steps, the source community token calls `PCEToken.transferDepositOnInterCommunitySwap(address(this), toTokenAddress, amountToSwap)`. The public ABI of `swapTokens` is unchanged.
+
+#### Storage
+
+No new storage. Existing slots used:
+
+- `PCEToken.localTokens[fromToken].depositedPCEToken` (decremented)
+- `PCEToken.localTokens[toToken].depositedPCEToken` (incremented)
+- `PCEToken.localTokens[fromToken].exchangeRate` (read)
+- `PCEToken.lastModifiedFactor` (read; updated by the `updateFactorIfNeeded()` call performed at the start of the function)
+
+#### Events
+
+```solidity
+event DepositTransferredOnInterCommunitySwap(
+    address indexed fromToken,
+    address indexed toToken,
+    uint256 fromDisplayAmount,
+    uint256 movedPceAmount
+);
+```
+
+Emitted by PCEToken on every successful call to `transferDepositOnInterCommunitySwap`, including the zero-`movedPceAmount` no-op short-circuit case described below.
+
+#### Algorithm
+
+The PCE-equivalent of `fromDisplayAmount` (display amount being swapped out of `fromToken`) is computed using the same formula already used by `swapFromLocalToken` (`PCEToken.sol:288-292`) and `swapFeeFromLocalToken` (`PCEToken.sol:333-337`):
+
+```
+movedPceAmount = mulDiv(
+    mulDiv(fromDisplayAmount, INITIAL_FACTOR, localTokens[fromToken].exchangeRate),
+    lastModifiedFactor,
+    PCECommunityToken(fromToken).getCurrentFactor()
+)
+```
+
+This is the same PCE quantity that would result from the indirect path `swapFromLocalToken(fromToken, fromDisplayAmount)`. Therefore, after this PIP, the direct A→B path produces the same `localTokens[A].depositedPCEToken` decrement and `localTokens[B].depositedPCEToken` increment as the indirect A→PCE→B path.
+
+**Steps in `transferDepositOnInterCommunitySwap`:**
+
+1. Verify `msg.sender == fromToken` (MUST).
+2. Verify `localTokens[fromToken].isExists` and `localTokens[toToken].isExists` (MUST).
+3. Verify `fromToken != toToken` (MUST).
+4. Call `updateFactorIfNeeded()` so `lastModifiedFactor` reflects the current epoch.
+5. Compute `movedPceAmount` using the formula above.
+6. If `movedPceAmount == 0`, emit `DepositTransferredOnInterCommunitySwap(fromToken, toToken, fromDisplayAmount, 0)` and return 0. (This short-circuit mirrors `swapFeeFromLocalToken`'s zero-amount handling and prevents bricking on dust-sized swaps.)
+7. Verify `localTokens[fromToken].depositedPCEToken >= movedPceAmount`; otherwise revert with `"Insufficient deposited PCE token reserve at source community"` (MUST).
+8. Decrement `localTokens[fromToken].depositedPCEToken` by `movedPceAmount`.
+9. Increment `localTokens[toToken].depositedPCEToken` by `movedPceAmount`.
+10. Emit `DepositTransferredOnInterCommunitySwap(fromToken, toToken, fromDisplayAmount, movedPceAmount)`.
+11. Return `movedPceAmount`.
+
+**Modified `PCECommunityToken.swapTokens`:**
+
+```solidity
+function swapTokens(address toTokenAddress, uint256 amountToSwap) public {
+    address sender = _msgSender();
+    updateFactorIfNeeded();
+    PCEToken pceToken = PCEToken(pceAddress);
+    pceToken.updateFactorIfNeeded();
+    PCECommunityToken to = PCECommunityToken(toTokenAddress);
+    to.updateFactorIfNeeded();
+
+    require(balanceOf(sender) >= amountToSwap, "Insufficient balance");
+    require(isAllowOutgoExchange(toTokenAddress), "Outgo exchange not allowed");
+    require(to.isAllowIncomeExchange(address(this)), "Income exchange not allowed");
+
+    uint256 targetTokenAmount = TokenValueOps.computeSwapAmount(
+        pceAddress, address(this), toTokenAddress, amountToSwap, getCurrentFactor(), to.getCurrentFactor()
+    );
+    super._burn(sender, displayBalanceToRawBalance(amountToSwap));
+    to.mint(sender, targetTokenAmount);
+
+    // PIP-17: migrate the PCE-equivalent reserve from the source community
+    // to the destination community to keep per-community deposit accounting
+    // consistent with the actual claim transferred.
+    pceToken.transferDepositOnInterCommunitySwap(address(this), toTokenAddress, amountToSwap);
+}
+```
+
+The new call is the only addition. All pre-existing checks, computations, and burn/mint operations are preserved unchanged.
+
+#### Authority
+
+`transferDepositOnInterCommunitySwap` follows the same pattern as `swapFeeFromLocalToken`: it is callable only by the registered community token instance that the call concerns (`msg.sender == fromToken`). No governance role and no community-owner role are involved. The function cannot be invoked by EOAs, generic multisigs, or any contract other than the source community token.
+
+There is no per-community opt-out: any direct inter-community swap initiated through `PCECommunityToken.swapTokens` performs the deposit migration. This is intentional — silent opt-outs would re-introduce the path-divergence between direct and indirect swaps that this PIP is designed to remove.
+
+### Rationale
+
+**Why a community-pool model rather than a global pool?**
+A separate proposal considered consolidating per-community deposit accounting into a single global pool, removing the per-community check from `swapFromLocalToken` and routing all swap-back validation against `balanceOf(address(this))`. After review, the protocol elected to retain per-community accounting because it preserves three properties that the global-pool design would have lost: (a) inter-community cross-subsidy is bounded — community A's deposit cannot silently pay for community B's swap-back; (b) governance reasoning at the per-community level remains tractable — a community's deposit number means what it appears to mean; (c) per-community swap-back failure surfaces under-collateralization at the right unit of attribution. PIP-17 is the minimal change that fixes the specific drift caused by direct A→B swaps **without** discarding the per-community model.
+
+**Why a new function on PCEToken rather than direct storage manipulation from PCECommunityToken?**
+`localTokens` is PCEToken's internal accounting state. The existing pattern for community tokens that need PCEToken to mutate this state is to call a PCEToken function gated to `msg.sender == fromToken` (see `swapFeeFromLocalToken`, `PCEToken.sol:321`). PIP-17 follows the same pattern. Direct cross-contract storage writes are not a feature of the existing architecture and would require either making `localTokens` writable by community tokens or duplicating the registry — both worse than reusing the established pattern.
+
+**Why move the full PCE-equivalent of the swap rather than a proportional share of the source deposit?**
+A proportional design (`movedPceAmount = sourceDeposit * rawShareLeaving / sourceTotalRawSupply`) was considered. It has the property that under-collateralized source communities can still complete inter-community swaps without revert. It was rejected because (a) it would silently understate the destination community's required reserve attribution — the destination acquires holders with full PCE-denominated claims, and partial deposit migration would push the under-collateralization onto the destination invisibly; (b) it would diverge from `swapFromLocalToken`'s strict "deposit must cover claim" semantics, breaking the path equivalence that PIP-17 is trying to establish; (c) revert on under-collateralized source is the correct surfacing behavior — it matches what would happen if the user used the indirect path `swapFromLocalToken → swapToLocalToken`.
+
+**Why call `transferDepositOnInterCommunitySwap` after the burn/mint rather than before?**
+Order does not affect the computed `movedPceAmount` (the formula depends on `fromDisplayAmount` and the source community's `exchangeRate` / `getCurrentFactor()`, none of which are changed by burn/mint). Calling after burn/mint keeps the `swapTokens` body's existing structure intact; the deposit-migration call is appended as the final step. If the call reverts (insufficient source deposit), the entire transaction reverts including the burn/mint, leaving the user's balance unchanged. This is the desired atomicity.
+
+**Why no new daily-limit accounting on inter-community swap?**
+Inter-community swaps currently do not consume `swappedToPCEToday` (the per-community daily swap-to-PCE limit), and PIP-17 does not change that. The daily limit was designed to throttle PCE outflow from the protocol, not internal claim transfers between communities. Making inter-community swap consume the limit would be a separable scope decision; see *Notes*.
+
+**Why no per-community opt-out?**
+A per-community flag to disable deposit migration would re-introduce the very drift this PIP fixes, in a configuration-dependent way. The migration is mandatory.
+
+### Backwards Compatibility
+
+All changes are additive at the public surface:
+
+- PCEToken: one new external function (`transferDepositOnInterCommunitySwap`), one new event (`DepositTransferredOnInterCommunitySwap`). No existing function signature changes. No storage layout changes (only existing slots are mutated).
+- PCECommunityToken: `swapTokens`'s public signature, parameters, and visibility are unchanged. The function body gains one additional call to PCEToken at the end. No new storage.
+- No changes to `swapFromLocalToken`, `swapToLocalToken`, `swapFeeFromLocalToken`, ARIGATO CREATION mint logic, decay logic, or any view function.
+
+`getDepositedPCETokens(community)` continues to return `localTokens[community].depositedPCEToken`. After PIP-17, the returned value reflects the corrected accounting (i.e., includes the effect of inter-community swaps). Off-chain readers that depend on this view will observe more accurate per-community deposits going forward. There is no migration of pre-PIP-17 historical drift: the existing on-chain state is taken as the new starting point, and accounting drifts only through future inter-community swaps.
+
+The existing indirect path (`swapFromLocalToken` → `swapToLocalToken`) continues to work exactly as before. Its post-state on `localTokens[*].depositedPCEToken` was already correct; PIP-17 makes the direct path produce the same post-state.
+
+Existing scripts, multisig batches, and governance proposals that invoke `swapTokens` continue to execute unchanged. The only externally-visible difference is that inter-community swap from a source community whose `depositedPCEToken` is below the PCE-equivalent of the swap amount will now revert, where it would previously have succeeded silently. This is the intended semantic correction.
+
+### Test Cases
+
+In all cases, INITIAL_FACTOR = 10^18, exchange rates and current factors are 1e18 unless noted, and BP_BASE = 10,000.
+
+**Case 1: Standard inter-community swap.**
+- Setup: communities A and B, both registered. `localTokens[A].depositedPCEToken = 100e18`, `localTokens[B].depositedPCEToken = 50e18`. `A.exchangeRate = 1e18`, both current factors = 1e18, `pceToken.lastModifiedFactor = 1e18`. User holds 30 display units of A.
+- Operation: user calls `A.swapTokens(B, 30e18)`.
+- Result: A burns 30e18 raw, B mints `targetTokenAmount` raw to user. PCEToken: `localTokens[A].depositedPCEToken = 70e18`, `localTokens[B].depositedPCEToken = 80e18`. Event `DepositTransferredOnInterCommunitySwap(A, B, 30e18, 30e18)` is emitted.
+
+**Case 2: Direct path matches indirect path.**
+- Setup: identical to Case 1.
+- Operation 2a (indirect): user calls `pceToken.swapFromLocalToken(A, 30e18)` then `pceToken.swapToLocalToken(B, 30e18)`.
+- Operation 2b (direct): from the same starting state, user calls `A.swapTokens(B, 30e18)`.
+- Result: post-state `localTokens[A].depositedPCEToken` and `localTokens[B].depositedPCEToken` are equal across the two operations. (This was not true before PIP-17.)
+
+**Case 3: Insufficient source deposit reverts.**
+- Setup: `localTokens[A].depositedPCEToken = 5e18`, otherwise as Case 1. User holds 30 display units of A (held due to ARIGATO CREATION accumulation that inflated supply beyond deposit).
+- Operation: user calls `A.swapTokens(B, 30e18)`.
+- Result: revert (`"Insufficient deposited PCE token reserve at source community"`). User's A balance and B's supply unchanged. Note: the same operation via `swapFromLocalToken(A, 30e18)` would also revert with `"Insufficient deposited PCE token reserve"` — behavior is now aligned across the two paths.
+
+**Case 4: Authorization.**
+- An EOA, a generic contract, or any community token other than A calls `pceToken.transferDepositOnInterCommunitySwap(A, B, 10e18)`.
+- Result: revert (`"Caller must be the from-side community token"`).
+
+**Case 5: Same-token guard.**
+- A calls `pceToken.transferDepositOnInterCommunitySwap(A, A, 10e18)` (e.g. via a misuse of `swapTokens`).
+- Result: revert (`"Same-token swap"`). (Note: `PCECommunityToken.swapTokens` would already revert earlier in such a case via existing logic; this is a defense-in-depth check at the PCEToken layer.)
+
+**Case 6: Unregistered destination.**
+- B is not registered (`localTokens[B].isExists == false`). User calls `A.swapTokens(B, 30e18)`.
+- Result: revert at the first registration check inside `transferDepositOnInterCommunitySwap` (`"To token not registered"`). The pre-existing `to.isAllowIncomeExchange(...)` call inside `swapTokens` would in practice fail earlier when `B` is not a deployed PCECommunityToken; this is a defense-in-depth check at the PCEToken layer.
+
+**Case 7: Dust swap (zero PCE-equivalent).**
+- Setup: `A.exchangeRate` is large enough that `mulDiv(1, INITIAL_FACTOR, A.exchangeRate)` rounds to 0.
+- Operation: user calls `A.swapTokens(B, 1)`. `transferDepositOnInterCommunitySwap` computes `movedPceAmount == 0`.
+- Result: deposit storage unchanged. Event `DepositTransferredOnInterCommunitySwap(A, B, 1, 0)` emitted. The outer `swapTokens`'s `targetTokenAmount > 0` check (inherited from `TokenValueOps.computeSwapAmount`) typically prevents this case from occurring at the swap layer; the zero-handling in `transferDepositOnInterCommunitySwap` is defensive.
+
+**Case 8: Multiple inter-community swaps preserve protocol-wide deposit total.**
+- Setup: arbitrary mix of registered communities, deposits, and users.
+- Operation: any sequence of `A.swapTokens(B, x)` calls.
+- Invariant: `sum over all registered communities of localTokens[c].depositedPCEToken` is unchanged by inter-community swaps. (PIP-17 redistributes between source and destination but neither mints nor burns deposit accounting.)
+
+### Security Considerations
+
+**Reentrancy.** `transferDepositOnInterCommunitySwap` only writes to PCEToken storage (`localTokens[fromToken].depositedPCEToken`, `localTokens[toToken].depositedPCEToken`), reads exchange rate / current factor, and emits an event. It calls `updateFactorIfNeeded()` (an existing internal PCEToken function with no external calls) and reads `PCECommunityToken(fromToken).getCurrentFactor()` (a `view` call into a registered community token). The only external call is the `view` to `getCurrentFactor`. Because `fromToken == msg.sender` is enforced and `msg.sender` is already executing, there is no new reentrancy surface beyond what `swapTokens` already exposes. Implementations SHOULD nonetheless follow checks-effects-interactions ordering for the state mutations.
+
+**Caller authorization.** The `msg.sender == fromToken` check assumes `fromToken` is a registered community token, which is then confirmed by the `localTokens[fromToken].isExists` check. An attacker cannot deploy an arbitrary contract that masquerades as a community token to drain deposits, because the registry membership check is enforced. The destination `localTokens[toToken].isExists` check prevents redirecting deposit accounting into an unregistered address.
+
+**Source under-collateralization surfaces correctly.** Before PIP-17, a user could exit a deeply under-collateralized community A via direct `swapTokens(B, ...)` because the path bypassed all deposit checks. After PIP-17, this path will revert, matching the indirect path's behavior. This is a hardening: it removes a silent escape route from under-collateralized communities. Communities and users SHOULD be aware that direct inter-community swap from an under-collateralized source will fail.
+
+**Front-running and ordering.** A user who observes a pending `swapTokens(B, large)` in the mempool and front-runs with `swapFromLocalToken(A, large)` may drain A's deposit and cause the pending direct swap to revert. Before PIP-17, the direct swap would have succeeded regardless. This is not a new attack vector — `swapFromLocalToken` is already first-come-first-served against A's deposit — but it now extends to inter-community swaps. The mitigation is the same as for ordinary swap-back: rely on per-block transaction ordering and the existing daily-swap limits.
+
+**Integer arithmetic.** The `movedPceAmount` formula uses `Math.mulDiv` to perform mulDiv-then-divide safely against overflow and to avoid precision loss. Implementations MUST use `Math.mulDiv` (or equivalent) and MUST NOT use the naive `(a * b) / c` form.
+
+**Cross-contract trust.** `transferDepositOnInterCommunitySwap`'s authorization model depends on `localTokens[*].isExists` being only set for code that conforms to the PCECommunityToken contract (i.e., the registry is the trust boundary). Adding non-conformant code to the registry would be a governance failure outside the scope of this PIP, and would already break many other parts of the system. PIP-17 introduces no new risk in this dimension.
+
+**Event coverage for off-chain accounting.** `DepositTransferredOnInterCommunitySwap` is emitted on every successful migration, including the `movedPceAmount == 0` short-circuit. Off-chain indexers can rely on this event as the single source of truth for inter-community deposit migrations and reconcile it against `Transfer`-equivalent burns/mints on the community tokens themselves.
+
+### Notes
+
+- **What this proposal guarantees:** for every direct inter-community swap via `PCECommunityToken.swapTokens(toToken, amount)`, the per-community PCE deposit accounting in `PCEToken.localTokens[*].depositedPCEToken` is updated atomically and consistently with the indirect A→PCE→B path. The total `sum localTokens[c].depositedPCEToken` across all registered communities is invariant under inter-community swap.
+- **What this proposal does not guarantee:**
+  - That per-community deposits cover per-community claims at all times. ARIGATO CREATION mints continue to inflate community-token claims without inflating deposits, and PCE BASE Token decay continues to erode claims without changing deposits. Both effects are out of scope and are properties of the existing reserve model.
+  - That inter-community swap from an under-collateralized source succeeds. Such swaps will revert (Case 3). This is the intended hardening.
+  - Any change to daily swap limits. Inter-community swap continues to be unconstrained by `swappedToPCEToday`.
+- **Out of scope:**
+  - Treating inter-community swap as consumption of the per-community daily swap-to-PCE limit. A separable design decision; if pursued, it should be a follow-up PIP that adds an explicit `recordSwapToPCE`-like call from `swapTokens`.
+  - Backfilling pre-PIP-17 deposit drift. The on-chain state at the time of upgrade is the new baseline; correcting historical drift would require off-chain analysis and a one-shot governance reconciliation transaction, both of which are separable.
+  - Restructuring the per-community reserve model into a global pool, or any related change to `swapFromLocalToken`'s deposit check. Considered and explicitly rejected in favor of preserving per-community accounting.
+- **Dependencies:** none. PIP-17 is implementable on the current `peacecoin-protocol/core` codebase (post-PIP-14 ownership semantics if active, but no functional dependency on PIP-14).
+- **Implementation reference:** `peacecoin-protocol/core` — affected files are `src/PCEToken.sol` (new function and event) and `src/PCECommunityToken.sol` (one-line addition at the end of `swapTokens`). No library changes (`src/lib/ArigatoCreation.sol`, `src/lib/TokenValueOps.sol`, `src/lib/TokenSetting.sol` are untouched).

--- a/PIPs/pip-17.md
+++ b/PIPs/pip-17.md
@@ -13,7 +13,7 @@ replaces: []
 
 ### Abstract
 
-This proposal fixes a long-standing accounting drift in inter-community community-token swaps. Today, when a user calls `PCECommunityToken.swapTokens(toToken, amount)` to swap directly from community A to community B, raw supply moves (burned on A, minted on B) but the per-community PCE reserve accounting in `PCEToken.localTokens[*].depositedPCEToken` does **not** move — even though the corresponding PCE-denominated claim now sits with B's holders. This proposal adds a single PCEToken function, `transferDepositOnInterCommunitySwap`, that is called by the source community token during `swapTokens` to move the PCE-equivalent of the swapped amount from the source community's deposit accounting to the destination community's deposit accounting. After this change, the direct A→B path becomes accounting-equivalent to the existing indirect A→PCE→B path. The per-community reserve model is retained.
+This proposal fixes a long-standing accounting drift in inter-community community-token swaps. Today, when a user calls `PCECommunityToken.swapTokens(toToken, amount)` to swap directly from community A to community B, raw supply is intended to move (burn on A, mint on B) but the per-community PCE reserve accounting in `PCEToken.localTokens[*].depositedPCEToken` does **not** move — and in fact, the destination-side `mint` call cannot succeed at all under the current code because `PCECommunityToken.mint` is gated to the PCEToken address. This proposal introduces a single PCEToken function, `executeInterCommunitySwap`, that the source community token calls after the source-side burn. PCEToken performs the deposit migration (moving the PCE-equivalent of the swapped amount from the source community's accounting to the destination community's accounting) and performs the destination-side mint (which it is authorized to do). After this change, the direct A→B path is functional end-to-end and becomes accounting-equivalent to the existing indirect A→PCE→B path. The per-community reserve model is retained.
 
 ### Motivation
 
@@ -23,7 +23,7 @@ This proposal fixes a long-standing accounting drift in inter-community communit
 - `swapFromLocalToken(A, amount)` (A → PCE): decrements `localTokens[A].depositedPCEToken` by the PCE-equivalent.
 - `swapFeeFromLocalToken(...)` (meta-tx fee path): decrements the source community's deposit by the PCE-equivalent fee.
 
-The fourth — direct community-to-community swap via `PCECommunityToken.swapTokens(toToken, amount)` — does not. It burns raw supply on the source and mints on the destination, but **never touches** `localTokens[fromToken].depositedPCEToken` or `localTokens[toToken].depositedPCEToken`. Over time and across many inter-community swaps, this produces a deposit-vs-claim drift between communities:
+The fourth — direct community-to-community swap via `PCECommunityToken.swapTokens(toToken, amount)` — does not. It is intended to burn raw supply on the source and mint on the destination, but **never touches** `localTokens[fromToken].depositedPCEToken` or `localTokens[toToken].depositedPCEToken`. (It also has a latent bug whereby the destination-side `mint(sender, targetTokenAmount)` call cannot succeed, because `PCECommunityToken.mint` is gated to the PCEToken address; the mint call is made from the source community token rather than from PCEToken, so the auth check rejects it. PIP-17 closes this by routing the mint through PCEToken alongside the deposit migration.) Over time and across many inter-community swaps, this produces a deposit-vs-claim drift between communities:
 
 - Source community A: holders have already exited (raw supply burned), but PCE reserve accounting still attributes that PCE backing to A.
 - Destination community B: holders now hold the claim (raw supply minted), but PCE reserve accounting attributes no additional backing to B.
@@ -42,18 +42,20 @@ Note: this proposal scope is narrow. It does **not** restructure the per-communi
 A new function is added to **PCEToken**:
 
 ```solidity
-function transferDepositOnInterCommunitySwap(
+function executeInterCommunitySwap(
     address fromToken,
     address toToken,
-    uint256 fromDisplayAmount
+    address recipient,
+    uint256 fromDisplayAmount,
+    uint256 toDisplayAmount
 ) external returns (uint256 movedPceAmount);
 ```
 
 **Authorization:** the caller MUST be the source community token: `require(msg.sender == fromToken, "Caller must be the from-side community token")`. Both `fromToken` and `toToken` MUST be registered (`localTokens[*].isExists`). `fromToken != toToken` MUST hold.
 
-**Behavior:** the function computes the PCE-equivalent of `fromDisplayAmount` using the source community's exchange rate and current factor, decrements `localTokens[fromToken].depositedPCEToken` by that amount, increments `localTokens[toToken].depositedPCEToken` by the same amount, and emits an event. If the source's recorded deposit is insufficient to cover the PCE-equivalent, the call MUST revert.
+**Behavior:** the function (a) computes the PCE-equivalent of `fromDisplayAmount` using the source community's exchange rate and current factor and migrates that amount of deposit from `localTokens[fromToken]` to `localTokens[toToken]`, then (b) calls `PCECommunityToken(toToken).mint(recipient, toDisplayAmount)`. The destination-side `mint` is performed by PCEToken (rather than by the source community token) because `PCECommunityToken.mint` is gated to the PCEToken address. If the source's recorded deposit is insufficient to cover the PCE-equivalent, the call MUST revert.
 
-**PCECommunityToken.swapTokens — modified behavior:** after the existing burn-on-source / mint-on-destination steps, the source community token calls `PCEToken.transferDepositOnInterCommunitySwap(address(this), toTokenAddress, amountToSwap)`. The public ABI of `swapTokens` is unchanged.
+**PCECommunityToken.swapTokens — modified behavior:** the source community token still performs the source-side burn and the swap-amount calculation. The destination-side mint is now delegated to PCEToken via `pceToken.executeInterCommunitySwap(address(this), toTokenAddress, sender, amountToSwap, targetTokenAmount)`. The public ABI of `swapTokens` is unchanged.
 
 #### Storage
 
@@ -63,6 +65,7 @@ No new storage. Existing slots used:
 - `PCEToken.localTokens[toToken].depositedPCEToken` (incremented)
 - `PCEToken.localTokens[fromToken].exchangeRate` (read)
 - `PCEToken.lastModifiedFactor` (read; updated by the `updateFactorIfNeeded()` call performed at the start of the function)
+- The destination community's `_balances` / `_totalSupply` (mutated by the embedded `mint` call)
 
 #### Events
 
@@ -75,7 +78,7 @@ event DepositTransferredOnInterCommunitySwap(
 );
 ```
 
-Emitted by PCEToken on every successful call to `transferDepositOnInterCommunitySwap`, including the zero-`movedPceAmount` no-op short-circuit case described below.
+Emitted by PCEToken on every successful call to `executeInterCommunitySwap`, including the zero-`movedPceAmount` no-op short-circuit case described below.
 
 #### Algorithm
 
@@ -91,19 +94,17 @@ movedPceAmount = mulDiv(
 
 This is the same PCE quantity that would result from the indirect path `swapFromLocalToken(fromToken, fromDisplayAmount)`. Therefore, after this PIP, the direct A→B path produces the same `localTokens[A].depositedPCEToken` decrement and `localTokens[B].depositedPCEToken` increment as the indirect A→PCE→B path.
 
-**Steps in `transferDepositOnInterCommunitySwap`:**
+**Steps in `executeInterCommunitySwap`:**
 
 1. Verify `msg.sender == fromToken` (MUST).
 2. Verify `localTokens[fromToken].isExists` and `localTokens[toToken].isExists` (MUST).
 3. Verify `fromToken != toToken` (MUST).
 4. Call `updateFactorIfNeeded()` so `lastModifiedFactor` reflects the current epoch.
 5. Compute `movedPceAmount` using the formula above.
-6. If `movedPceAmount == 0`, emit `DepositTransferredOnInterCommunitySwap(fromToken, toToken, fromDisplayAmount, 0)` and return 0. (This short-circuit mirrors `swapFeeFromLocalToken`'s zero-amount handling and prevents bricking on dust-sized swaps.)
-7. Verify `localTokens[fromToken].depositedPCEToken >= movedPceAmount`; otherwise revert with `"Insufficient deposited PCE token reserve at source community"` (MUST).
-8. Decrement `localTokens[fromToken].depositedPCEToken` by `movedPceAmount`.
-9. Increment `localTokens[toToken].depositedPCEToken` by `movedPceAmount`.
-10. Emit `DepositTransferredOnInterCommunitySwap(fromToken, toToken, fromDisplayAmount, movedPceAmount)`.
-11. Return `movedPceAmount`.
+6. If `movedPceAmount > 0`: verify `localTokens[fromToken].depositedPCEToken >= movedPceAmount`, otherwise revert with `"Insufficient deposited PCE token reserve at source community"` (MUST). Then decrement `localTokens[fromToken].depositedPCEToken` and increment `localTokens[toToken].depositedPCEToken` by `movedPceAmount`. (When `movedPceAmount == 0`, no deposit accounting changes are made; this short-circuit mirrors `swapFeeFromLocalToken`'s zero-amount handling and prevents bricking on dust-sized swaps.)
+7. Call `PCECommunityToken(toToken).mint(recipient, toDisplayAmount)`. The mint succeeds because PCEToken is the authorized caller for `PCECommunityToken.mint`.
+8. Emit `DepositTransferredOnInterCommunitySwap(fromToken, toToken, fromDisplayAmount, movedPceAmount)`.
+9. Return `movedPceAmount`.
 
 **Modified `PCECommunityToken.swapTokens`:**
 
@@ -124,20 +125,22 @@ function swapTokens(address toTokenAddress, uint256 amountToSwap) public {
         pceAddress, address(this), toTokenAddress, amountToSwap, getCurrentFactor(), to.getCurrentFactor()
     );
     super._burn(sender, displayBalanceToRawBalance(amountToSwap));
-    to.mint(sender, targetTokenAmount);
 
-    // PIP-17: migrate the PCE-equivalent reserve from the source community
-    // to the destination community to keep per-community deposit accounting
-    // consistent with the actual claim transferred.
-    pceToken.transferDepositOnInterCommunitySwap(address(this), toTokenAddress, amountToSwap);
+    // PIP-17: PCEToken handles deposit migration AND the destination-side mint
+    // (which is gated to PCEToken). This both fixes the latent inability of
+    // pre-PIP-17 swapTokens to mint on the destination community, and ensures
+    // per-community deposit accounting tracks the actual claim transferred.
+    pceToken.executeInterCommunitySwap(
+        address(this), toTokenAddress, sender, amountToSwap, targetTokenAmount
+    );
 }
 ```
 
-The new call is the only addition. All pre-existing checks, computations, and burn/mint operations are preserved unchanged.
+The previous `to.mint(sender, targetTokenAmount)` call is removed and replaced by the `executeInterCommunitySwap` call which performs both the mint and the deposit migration atomically.
 
 #### Authority
 
-`transferDepositOnInterCommunitySwap` follows the same pattern as `swapFeeFromLocalToken`: it is callable only by the registered community token instance that the call concerns (`msg.sender == fromToken`). No governance role and no community-owner role are involved. The function cannot be invoked by EOAs, generic multisigs, or any contract other than the source community token.
+`executeInterCommunitySwap` follows the same pattern as `swapFeeFromLocalToken`: it is callable only by the registered community token instance that the call concerns (`msg.sender == fromToken`). No governance role and no community-owner role are involved. The function cannot be invoked by EOAs, generic multisigs, or any contract other than the source community token.
 
 There is no per-community opt-out: any direct inter-community swap initiated through `PCECommunityToken.swapTokens` performs the deposit migration. This is intentional — silent opt-outs would re-introduce the path-divergence between direct and indirect swaps that this PIP is designed to remove.
 
@@ -152,8 +155,11 @@ A separate proposal considered consolidating per-community deposit accounting in
 **Why move the full PCE-equivalent of the swap rather than a proportional share of the source deposit?**
 A proportional design (`movedPceAmount = sourceDeposit * rawShareLeaving / sourceTotalRawSupply`) was considered. It has the property that under-collateralized source communities can still complete inter-community swaps without revert. It was rejected because (a) it would silently understate the destination community's required reserve attribution — the destination acquires holders with full PCE-denominated claims, and partial deposit migration would push the under-collateralization onto the destination invisibly; (b) it would diverge from `swapFromLocalToken`'s strict "deposit must cover claim" semantics, breaking the path equivalence that PIP-17 is trying to establish; (c) revert on under-collateralized source is the correct surfacing behavior — it matches what would happen if the user used the indirect path `swapFromLocalToken → swapToLocalToken`.
 
-**Why call `transferDepositOnInterCommunitySwap` after the burn/mint rather than before?**
-Order does not affect the computed `movedPceAmount` (the formula depends on `fromDisplayAmount` and the source community's `exchangeRate` / `getCurrentFactor()`, none of which are changed by burn/mint). Calling after burn/mint keeps the `swapTokens` body's existing structure intact; the deposit-migration call is appended as the final step. If the call reverts (insufficient source deposit), the entire transaction reverts including the burn/mint, leaving the user's balance unchanged. This is the desired atomicity.
+**Why bundle the destination-side mint into PCEToken's new function rather than keep it in PCECommunityToken?**
+`PCECommunityToken.mint` is gated to `_msgSender() == pceAddress`, so it can only be invoked from PCEToken. Pre-PIP-17 code attempted `to.mint(sender, targetTokenAmount)` directly from the source community token, which would fail the auth check at runtime — making `swapTokens` non-functional. PIP-17 routes the mint through `executeInterCommunitySwap` so PCEToken (the authorized caller) performs it. This both fixes the latent bug and avoids widening `PCECommunityToken.mint`'s authorization to all registered community tokens, which would expand the trust surface unnecessarily.
+
+**Why call `executeInterCommunitySwap` after the source-side burn rather than before?**
+Order does not affect the computed `movedPceAmount` (the formula depends on `fromDisplayAmount` and the source community's `exchangeRate` / `getCurrentFactor()`, none of which are changed by burn). Calling after burn keeps the `swapTokens` body's source-side operations grouped, with the destination-side operations (deposit migration + mint) delegated together to PCEToken. If the call reverts (insufficient source deposit, unregistered destination, etc.), the entire transaction reverts including the burn, leaving the user's source-token balance unchanged. This is the desired atomicity.
 
 **Why no new daily-limit accounting on inter-community swap?**
 Inter-community swaps currently do not consume `swappedToPCEToday` (the per-community daily swap-to-PCE limit), and PIP-17 does not change that. The daily limit was designed to throttle PCE outflow from the protocol, not internal claim transfers between communities. Making inter-community swap consume the limit would be a separable scope decision; see *Notes*.
@@ -163,17 +169,17 @@ A per-community flag to disable deposit migration would re-introduce the very dr
 
 ### Backwards Compatibility
 
-All changes are additive at the public surface:
+PCEToken changes are purely additive: one new external function (`executeInterCommunitySwap`), one new event (`DepositTransferredOnInterCommunitySwap`). No existing function signature changes. No storage layout changes (only existing slots are mutated).
 
-- PCEToken: one new external function (`transferDepositOnInterCommunitySwap`), one new event (`DepositTransferredOnInterCommunitySwap`). No existing function signature changes. No storage layout changes (only existing slots are mutated).
-- PCECommunityToken: `swapTokens`'s public signature, parameters, and visibility are unchanged. The function body gains one additional call to PCEToken at the end. No new storage.
-- No changes to `swapFromLocalToken`, `swapToLocalToken`, `swapFeeFromLocalToken`, ARIGATO CREATION mint logic, decay logic, or any view function.
+PCECommunityToken changes are minimal at the public surface: `swapTokens`'s public signature, parameters, and visibility are unchanged. Internally, the destination-side `to.mint(sender, targetTokenAmount)` call is removed and replaced by the `pceToken.executeInterCommunitySwap(...)` call which performs both the mint and the deposit migration. No new storage.
+
+No changes to `swapFromLocalToken`, `swapToLocalToken`, `swapFeeFromLocalToken`, ARIGATO CREATION mint logic, decay logic, or any view function.
 
 `getDepositedPCETokens(community)` continues to return `localTokens[community].depositedPCEToken`. After PIP-17, the returned value reflects the corrected accounting (i.e., includes the effect of inter-community swaps). Off-chain readers that depend on this view will observe more accurate per-community deposits going forward. There is no migration of pre-PIP-17 historical drift: the existing on-chain state is taken as the new starting point, and accounting drifts only through future inter-community swaps.
 
 The existing indirect path (`swapFromLocalToken` → `swapToLocalToken`) continues to work exactly as before. Its post-state on `localTokens[*].depositedPCEToken` was already correct; PIP-17 makes the direct path produce the same post-state.
 
-Existing scripts, multisig batches, and governance proposals that invoke `swapTokens` continue to execute unchanged. The only externally-visible difference is that inter-community swap from a source community whose `depositedPCEToken` is below the PCE-equivalent of the swap amount will now revert, where it would previously have succeeded silently. This is the intended semantic correction.
+Existing scripts, multisig batches, and governance proposals that invoke `swapTokens` continue to use the same external signature. Since pre-PIP-17 `swapTokens` was non-functional in practice (the destination-side mint reverted on auth), no integrations could have been relying on it for state mutation; PIP-17 makes the function functional. After PIP-17, inter-community swap from a source community whose `depositedPCEToken` is below the PCE-equivalent of the swap amount will revert.
 
 ### Test Cases
 
@@ -191,26 +197,26 @@ In all cases, INITIAL_FACTOR = 10^18, exchange rates and current factors are 1e1
 - Result: post-state `localTokens[A].depositedPCEToken` and `localTokens[B].depositedPCEToken` are equal across the two operations. (This was not true before PIP-17.)
 
 **Case 3: Insufficient source deposit reverts.**
-- Setup: `localTokens[A].depositedPCEToken = 5e18`, otherwise as Case 1. User holds 30 display units of A (held due to ARIGATO CREATION accumulation that inflated supply beyond deposit).
+- Setup: `localTokens[A].depositedPCEToken = 5e18`, otherwise as Case 1. User holds 30 display units of A (e.g. via ARIGATO CREATION accumulation that inflated supply beyond deposit).
 - Operation: user calls `A.swapTokens(B, 30e18)`.
-- Result: revert (`"Insufficient deposited PCE token reserve at source community"`). User's A balance and B's supply unchanged. Note: the same operation via `swapFromLocalToken(A, 30e18)` would also revert with `"Insufficient deposited PCE token reserve"` — behavior is now aligned across the two paths.
+- Result: revert (`"Insufficient deposited PCE token reserve at source community"`). User's A balance and B's supply unchanged. The same operation via `swapFromLocalToken(A, 30e18)` would also revert with `"Insufficient deposited PCE token reserve"` — behavior is aligned across the two paths.
 
 **Case 4: Authorization.**
-- An EOA, a generic contract, or any community token other than A calls `pceToken.transferDepositOnInterCommunitySwap(A, B, 10e18)`.
+- An EOA, a generic contract, or any community token other than A calls `pceToken.executeInterCommunitySwap(A, B, recipient, 10e18, 10e18)`.
 - Result: revert (`"Caller must be the from-side community token"`).
 
 **Case 5: Same-token guard.**
-- A calls `pceToken.transferDepositOnInterCommunitySwap(A, A, 10e18)` (e.g. via a misuse of `swapTokens`).
+- A calls `pceToken.executeInterCommunitySwap(A, A, recipient, 10e18, 10e18)` (e.g. via a misuse of `swapTokens`).
 - Result: revert (`"Same-token swap"`). (Note: `PCECommunityToken.swapTokens` would already revert earlier in such a case via existing logic; this is a defense-in-depth check at the PCEToken layer.)
 
 **Case 6: Unregistered destination.**
 - B is not registered (`localTokens[B].isExists == false`). User calls `A.swapTokens(B, 30e18)`.
-- Result: revert at the first registration check inside `transferDepositOnInterCommunitySwap` (`"To token not registered"`). The pre-existing `to.isAllowIncomeExchange(...)` call inside `swapTokens` would in practice fail earlier when `B` is not a deployed PCECommunityToken; this is a defense-in-depth check at the PCEToken layer.
+- Result: revert at the first registration check inside `executeInterCommunitySwap` (`"To token not registered"`). The pre-existing `to.isAllowIncomeExchange(...)` call inside `swapTokens` would in practice fail earlier when `B` is not a deployed PCECommunityToken; this is a defense-in-depth check at the PCEToken layer.
 
 **Case 7: Dust swap (zero PCE-equivalent).**
 - Setup: `A.exchangeRate` is large enough that `mulDiv(1, INITIAL_FACTOR, A.exchangeRate)` rounds to 0.
-- Operation: user calls `A.swapTokens(B, 1)`. `transferDepositOnInterCommunitySwap` computes `movedPceAmount == 0`.
-- Result: deposit storage unchanged. Event `DepositTransferredOnInterCommunitySwap(A, B, 1, 0)` emitted. The outer `swapTokens`'s `targetTokenAmount > 0` check (inherited from `TokenValueOps.computeSwapAmount`) typically prevents this case from occurring at the swap layer; the zero-handling in `transferDepositOnInterCommunitySwap` is defensive.
+- Operation: user calls `A.swapTokens(B, 1)`. `executeInterCommunitySwap` computes `movedPceAmount == 0`, so deposit accounting is unchanged; the destination-side `mint` still proceeds with the (similarly small) `toDisplayAmount`.
+- Result: deposit storage unchanged. Event `DepositTransferredOnInterCommunitySwap(A, B, 1, 0)` emitted. The outer `swapTokens`'s `targetTokenAmount > 0` check (inherited from `TokenValueOps.computeSwapAmount`) typically prevents this case from occurring at the swap layer; the zero-handling in `executeInterCommunitySwap` is defensive.
 
 **Case 8: Multiple inter-community swaps preserve protocol-wide deposit total.**
 - Setup: arbitrary mix of registered communities, deposits, and users.
@@ -219,17 +225,17 @@ In all cases, INITIAL_FACTOR = 10^18, exchange rates and current factors are 1e1
 
 ### Security Considerations
 
-**Reentrancy.** `transferDepositOnInterCommunitySwap` only writes to PCEToken storage (`localTokens[fromToken].depositedPCEToken`, `localTokens[toToken].depositedPCEToken`), reads exchange rate / current factor, and emits an event. It calls `updateFactorIfNeeded()` (an existing internal PCEToken function with no external calls) and reads `PCECommunityToken(fromToken).getCurrentFactor()` (a `view` call into a registered community token). The only external call is the `view` to `getCurrentFactor`. Because `fromToken == msg.sender` is enforced and `msg.sender` is already executing, there is no new reentrancy surface beyond what `swapTokens` already exposes. Implementations SHOULD nonetheless follow checks-effects-interactions ordering for the state mutations.
+**Reentrancy.** `executeInterCommunitySwap` writes to PCEToken storage (`localTokens[fromToken].depositedPCEToken`, `localTokens[toToken].depositedPCEToken`), reads exchange rate / current factor, calls `PCECommunityToken(toToken).mint(recipient, toDisplayAmount)` (an external call into a registered community token), and emits an event. The only writes-then-external-call sequence is "deposit migration → destination mint." Both the source and destination community tokens are members of the trusted registry (`localTokens[*].isExists`), and `mint` is a non-reentrant operation against PCEToken (it does not call back into PCEToken). Because `fromToken == msg.sender` is enforced and `msg.sender` is already executing, there is no new reentrancy surface beyond what `swapTokens` already exposes. Implementations SHOULD nonetheless follow checks-effects-interactions ordering for the state mutations.
 
 **Caller authorization.** The `msg.sender == fromToken` check assumes `fromToken` is a registered community token, which is then confirmed by the `localTokens[fromToken].isExists` check. An attacker cannot deploy an arbitrary contract that masquerades as a community token to drain deposits, because the registry membership check is enforced. The destination `localTokens[toToken].isExists` check prevents redirecting deposit accounting into an unregistered address.
 
-**Source under-collateralization surfaces correctly.** Before PIP-17, a user could exit a deeply under-collateralized community A via direct `swapTokens(B, ...)` because the path bypassed all deposit checks. After PIP-17, this path will revert, matching the indirect path's behavior. This is a hardening: it removes a silent escape route from under-collateralized communities. Communities and users SHOULD be aware that direct inter-community swap from an under-collateralized source will fail.
+**Source under-collateralization surfaces correctly.** Before PIP-17, the `swapTokens` path was non-functional (reverted at the destination-side `mint` auth check), so the question of under-collateralized exits via this path did not arise in practice. With `swapTokens` made functional by PIP-17, the path is also under deposit-cover semantics: an attempt to swap from a source whose recorded deposit is below the swap's PCE-equivalent will revert with `"Insufficient deposited PCE token reserve at source community"`. This matches the indirect path (`swapFromLocalToken`) and is the correct surfacing behavior. Communities and users SHOULD be aware that direct inter-community swap from an under-collateralized source will fail.
 
 **Front-running and ordering.** A user who observes a pending `swapTokens(B, large)` in the mempool and front-runs with `swapFromLocalToken(A, large)` may drain A's deposit and cause the pending direct swap to revert. Before PIP-17, the direct swap would have succeeded regardless. This is not a new attack vector — `swapFromLocalToken` is already first-come-first-served against A's deposit — but it now extends to inter-community swaps. The mitigation is the same as for ordinary swap-back: rely on per-block transaction ordering and the existing daily-swap limits.
 
 **Integer arithmetic.** The `movedPceAmount` formula uses `Math.mulDiv` to perform mulDiv-then-divide safely against overflow and to avoid precision loss. Implementations MUST use `Math.mulDiv` (or equivalent) and MUST NOT use the naive `(a * b) / c` form.
 
-**Cross-contract trust.** `transferDepositOnInterCommunitySwap`'s authorization model depends on `localTokens[*].isExists` being only set for code that conforms to the PCECommunityToken contract (i.e., the registry is the trust boundary). Adding non-conformant code to the registry would be a governance failure outside the scope of this PIP, and would already break many other parts of the system. PIP-17 introduces no new risk in this dimension.
+**Cross-contract trust.** `executeInterCommunitySwap`'s authorization model depends on `localTokens[*].isExists` being only set for code that conforms to the PCECommunityToken contract (i.e., the registry is the trust boundary). Adding non-conformant code to the registry would be a governance failure outside the scope of this PIP, and would already break many other parts of the system. PIP-17 introduces no new risk in this dimension.
 
 **Event coverage for off-chain accounting.** `DepositTransferredOnInterCommunitySwap` is emitted on every successful migration, including the `movedPceAmount == 0` short-circuit. Off-chain indexers can rely on this event as the single source of truth for inter-community deposit migrations and reconcile it against `Transfer`-equivalent burns/mints on the community tokens themselves.
 
@@ -245,4 +251,4 @@ In all cases, INITIAL_FACTOR = 10^18, exchange rates and current factors are 1e1
   - Backfilling pre-PIP-17 deposit drift. The on-chain state at the time of upgrade is the new baseline; correcting historical drift would require off-chain analysis and a one-shot governance reconciliation transaction, both of which are separable.
   - Restructuring the per-community reserve model into a global pool, or any related change to `swapFromLocalToken`'s deposit check. Considered and explicitly rejected in favor of preserving per-community accounting.
 - **Dependencies:** none. PIP-17 is implementable on the current `peacecoin-protocol/core` codebase (post-PIP-14 ownership semantics if active, but no functional dependency on PIP-14).
-- **Implementation reference:** `peacecoin-protocol/core` — affected files are `src/PCEToken.sol` (new function and event) and `src/PCECommunityToken.sol` (one-line addition at the end of `swapTokens`). No library changes (`src/lib/ArigatoCreation.sol`, `src/lib/TokenValueOps.sol`, `src/lib/TokenSetting.sol` are untouched).
+- **Implementation reference:** `peacecoin-protocol/core` — affected files are `src/PCEToken.sol` (new function and event) and `src/PCECommunityToken.sol` (replace `to.mint(...)` in `swapTokens` with the `pceToken.executeInterCommunitySwap(...)` call). No library changes (`src/lib/ArigatoCreation.sol`, `src/lib/TokenValueOps.sol`, `src/lib/TokenSetting.sol` are untouched).


### PR DESCRIPTION
## Summary

- Add PIP-17: Deposit Migration on Inter-community Swap
- **PIP full text**: [PIPs/pip-17.md](https://github.com/peacecoin-protocol/PIPs/blob/pip-17/PIPs/pip-17.md)
- Implementation: peacecoin-protocol/core PR (TBD)
- Background discussion (resulted in retaining per-community pool model): [reserve-pool note](https://github.com/nihen/nihen.github.io/tree/main/peacecoin-protocol/reserve-pool)

## Abstract

This proposal fixes a long-standing accounting drift in inter-community community-token swaps. Today, when a user calls `PCECommunityToken.swapTokens(toToken, amount)` to swap directly from community A to community B, raw supply moves (burned on A, minted on B) but the per-community PCE reserve accounting in `PCEToken.localTokens[*].depositedPCEToken` does **not** move — even though the corresponding PCE-denominated claim now sits with B's holders. This proposal adds a single PCEToken function, `executeInterCommunitySwap`, that is called by the source community token during `swapTokens` to move the PCE-equivalent of the swapped amount from the source community's deposit accounting to the destination community's deposit accounting. After this change, the direct A→B path becomes accounting-equivalent to the existing indirect A→PCE→B path. The per-community reserve model is retained.

### Key Points

- **`swapTokens` body simplified**: the destination-side `to.mint(sender, ...)` call is removed; in its place, a single `pceToken.executeInterCommunitySwap(address(this), toToken, sender, amount, targetTokenAmount)` call delegates both deposit migration and the destination-side mint to PCEToken. Public ABI of `swapTokens` is unchanged.
- **New PCEToken function**: `executeInterCommunitySwap(fromToken, toToken, recipient, fromDisplayAmount, toDisplayAmount) returns (uint256 movedPceAmount)`, gated to `msg.sender == fromToken` (mirrors the existing `swapFeeFromLocalToken` authorization pattern).
- **Same formula as `swapFromLocalToken`**: PCE-equivalent computed via `mulDiv(mulDiv(amount, INITIAL_FACTOR, exchangeRate), lastModifiedFactor, currentFactor)`. Direct A→B and indirect A→PCE→B now produce identical post-state.
- **Latent bug fix**: pre-PIP-17 `swapTokens` could not succeed end-to-end because `PCECommunityToken.mint` is gated to PCEToken, but `swapTokens` invoked it from the source community token. PIP-17 routes the mint through PCEToken, where the auth check naturally passes — without widening `mint`'s authorization.
- **Per-community pool model preserved**: a separate global-pool design was considered and explicitly rejected. PIP-17 is the minimal change that makes deposit accounting consistent without restructuring the reserve model.
- **Strict, not proportional**: under-collateralized source reverts (matches `swapFromLocalToken` semantics).
- **No new storage, no new auth surface, no daily-limit changes**: only existing `localTokens[*].depositedPCEToken` slots are mutated; only the source community token can invoke; daily swap-to-PCE limits are unaffected (out of scope).
- **Protocol-wide invariant**: sum of `localTokens[c].depositedPCEToken` across all registered communities is preserved by inter-community swap.

### Path Equivalence (Before vs After)

| | Direct path: `A.swapTokens(B, x)` | Indirect path: `swapFromLocalToken(A, x)` then `swapToLocalToken(B, pceAmount)` |
|---|---|---|
| Source-side burn on A | ✓ (already) | ✓ (already) |
| Destination-side mint on B | **before: ✗ (reverted) / after: ✓** | ✓ (already) |
| `localTokens[A].depositedPCEToken` decrement | **before: ✗ / after: ✓** | ✓ (already) |
| `localTokens[B].depositedPCEToken` increment | **before: ✗ / after: ✓** | ✓ (already) |
| Reverts on under-collateralized A | **before: n/a (whole call reverted) / after: ✓** | ✓ (already) |

### Background

`PCEToken.localTokens[community].depositedPCEToken` tracks the per-community PCE reserve. Three of four reserve-affecting flows already maintain this accounting correctly: `swapToLocalToken` (PCE→B), `swapFromLocalToken` (A→PCE), `swapFeeFromLocalToken` (meta-tx fee). The fourth — `PCECommunityToken.swapTokens` — does not. This produces accounting drift where holders of B effectively hold claims backed by PCE that is still attributed to A.

The protocol considered consolidating to a global pool (eliminating per-community deposit checks entirely) but elected to retain the per-community reserve model: cross-community subsidy stays bounded, governance reasoning at the community level stays tractable, and per-community swap-back failure surfaces under-collateralization at the right unit of attribution. PIP-17 is the minimal change that fixes the swap-time drift while preserving these properties.

Out of scope (separable, may be addressed by follow-up PIPs): ARIGATO CREATION mint inflating claims without inflating deposits, PCE BASE Token decay eroding claims, and treating inter-community swap as consumption of `swappedToPCEToday`.

---

<details><summary>日本語版 PIP 全文</summary>

```
---
pip: 17
title: Deposit Migration on Inter-community Swap
proposer: CHIBA Masahiro (@nihen)
status: Draft
type: Core
created: 2026-05-01
requires: []
replaces: []
---
```

## PIP-17: コミュニティ間 swap における PCE 準備金の移動

### Abstract（要約）

本提案は、コミュニティトークン間の直接 swap における長らく残っていた会計ズレを修正する。現状、ユーザーが `PCECommunityToken.swapTokens(toToken, amount)` を呼んでコミュニティ A から B へ直接 swap すると、raw 供給は移動する（A で burn、B で mint）が、`PCEToken.localTokens[*].depositedPCEToken` のコミュニティ毎 PCE 準備金会計は **移動しない** — 対応する PCE 換算 claim が B のホルダーに渡っているにもかかわらず。本提案は、PCEToken に `executeInterCommunitySwap` という単一の関数を追加し、`swapTokens` 中に source 側コミュニティトークンから呼ばれることで、swap 量の PCE 換算分を source コミュニティの預金会計から destination コミュニティの預金会計に移す。本変更後、直接 A→B 経路は既存の間接 A→PCE→B 経路と会計的に等価になる。コミュニティ毎の準備金モデルは維持される。

### Motivation

`PCEToken` は `localTokens[community].depositedPCEToken` を介して、コミュニティ毎に PCE 準備金を追跡している。準備金に影響する 4 つのフローのうち、3 つは会計を正しく維持している:

- `swapToLocalToken(B, amount)` (PCE → B): `localTokens[B].depositedPCEToken` を `amount` 分増加。
- `swapFromLocalToken(A, amount)` (A → PCE): `localTokens[A].depositedPCEToken` を PCE 換算分減少。
- `swapFeeFromLocalToken(...)` (meta-tx 手数料経路): source コミュニティの預金を fee の PCE 換算分減少。

4 つ目 — `PCECommunityToken.swapTokens(toToken, amount)` 経由のコミュニティ間直接 swap — は維持していない。source 側で raw 供給を burn し destination 側で mint するが、`localTokens[fromToken].depositedPCEToken` も `localTokens[toToken].depositedPCEToken` も **一切触らない**。多数のコミュニティ間 swap を経るうちに、コミュニティ間で「預金 vs claim」のズレが発生する:

- Source A: ホルダーは既に退出している（raw 供給 burn 済み）が、PCE 準備金会計は依然としてその PCE 裏付けを A に帰属させている。
- Destination B: ホルダーは現在 claim を保持している（raw 供給 mint 済み）が、PCE 準備金会計は B への追加裏付けを認識していない。

帰結は 2 つ:

1. **コミュニティ毎の swap-back 公平性が壊れる。** B ホルダーが後で `swapFromLocalToken(B, ...)` を呼んで PCE に退出するとき、成否判定 (`localTokens[B].depositedPCEToken >= pcetokenAmount`) は、コミュニティ間 swap で実際に B に入ってきた PCE を反映しない数字を参照する。プロトコル全体の PCE 換算では B 帰属の預金があるべき状況でも、B が swap-back に失敗し得る。
2. **経路の等価性が壊れる。** A のトークンから B のトークンに移りたいユーザーには 2 つの経路がある: 間接 (`swapFromLocalToken(A) → swapToLocalToken(B)`) と直接 (`swapTokens(B)`)。経済的には等価であるべきだが、`localTokens[*].depositedPCEToken` における事後状態は **異なる**。これはガバナンス、オフチェーン会計、コミュニティ毎預金値を読む将来のロジックすべてにとって落とし穴となる。

注: 本提案のスコープは狭い。コミュニティ毎の準備金モデルをグローバルプールに再構成 **しない**（明示的に検討の上で却下された別代替案）。同じ設計議論で挙げられた直交ドリフト群 — ARIGATO CREATION のミントが claim を膨張させるが預金は増えない、および PCE BASE Token の減衰が claim を侵食するが預金は変わらない — も対象外。これらは既存準備金モデルのコミュニティ毎の特性であり、本 PIP の範囲外。

### Specification（仕様）

#### Interface（インターフェース）

**PCEToken** に新関数を追加する:

```solidity
function executeInterCommunitySwap(
    address fromToken,
    address toToken,
    address recipient,
    uint256 fromDisplayAmount,
    uint256 toDisplayAmount
) external returns (uint256 movedPceAmount);
```

**権限:** 呼び出し元は source コミュニティトークンでなければならない: `require(msg.sender == fromToken, "Caller must be the from-side community token")`（MUST）。`fromToken` と `toToken` の両方が登録済み (`localTokens[*].isExists`) でなければならない（MUST）。`fromToken != toToken` を満たさなければならない（MUST）。

**動作:** (a) source コミュニティの exchange rate と current factor を用いて `fromDisplayAmount` の PCE 換算を計算し、`localTokens[fromToken]` から `localTokens[toToken]` へ預金を移動する、(b) `PCECommunityToken(toToken).mint(recipient, toDisplayAmount)` を呼ぶ。destination 側の `mint` は PCEToken 自身が行う（source コミュニティトークンからの直接呼び出しは `PCECommunityToken.mint` の auth gate に阻まれるため）。source 側の記録預金が PCE 換算をカバーするのに不足している場合、call は revert しなければならない（MUST）。

**PCECommunityToken.swapTokens — 動作変更:** source コミュニティトークンは引き続き source 側 burn と swap 量計算を行う。destination 側 mint は `pceToken.executeInterCommunitySwap(address(this), toTokenAddress, sender, amountToSwap, targetTokenAmount)` を介して PCEToken に委譲する。`swapTokens` の public ABI は変更しない。

#### Storage（ストレージ）

新規ストレージなし。使用する既存スロット:

- `PCEToken.localTokens[fromToken].depositedPCEToken`（減算）
- `PCEToken.localTokens[toToken].depositedPCEToken`（加算）
- `PCEToken.localTokens[fromToken].exchangeRate`（読み取り）
- `PCEToken.lastModifiedFactor`（読み取り; 関数冒頭の `updateFactorIfNeeded()` 呼び出しで更新）

#### Events（イベント）

```solidity
event DepositTransferredOnInterCommunitySwap(
    address indexed fromToken,
    address indexed toToken,
    uint256 fromDisplayAmount,
    uint256 movedPceAmount
);
```

`executeInterCommunitySwap` の成功時、PCEToken から発行される。後述する `movedPceAmount == 0` の no-op short-circuit ケースも含む。

#### Algorithm（アルゴリズム）

`fromDisplayAmount`（fromToken から swap される display 額）の PCE 換算は、`swapFromLocalToken` (`PCEToken.sol:288-292`) と `swapFeeFromLocalToken` (`PCEToken.sol:333-337`) で既に使われているのと同じ式で計算する:

```
movedPceAmount = mulDiv(
    mulDiv(fromDisplayAmount, INITIAL_FACTOR, localTokens[fromToken].exchangeRate),
    lastModifiedFactor,
    PCECommunityToken(fromToken).getCurrentFactor()
)
```

これは間接経路 `swapFromLocalToken(fromToken, fromDisplayAmount)` から得られるのと同じ PCE 量である。したがって本 PIP 後、直接 A→B 経路は間接 A→PCE→B 経路と同じ `localTokens[A].depositedPCEToken` 減算と `localTokens[B].depositedPCEToken` 加算を生じる。

**`executeInterCommunitySwap` のステップ:**

1. `msg.sender == fromToken` を検証（MUST）。
2. `localTokens[fromToken].isExists` および `localTokens[toToken].isExists` を検証（MUST）。
3. `fromToken != toToken` を検証（MUST）。
4. `updateFactorIfNeeded()` を呼んで `lastModifiedFactor` を現エポックに反映する。
5. 上記の式で `movedPceAmount` を計算。
6. `movedPceAmount == 0` なら、`DepositTransferredOnInterCommunitySwap(fromToken, toToken, fromDisplayAmount, 0)` を発行して 0 を返す。（この short-circuit は `swapFeeFromLocalToken` のゼロ額ハンドリングと同等で、塵レベルの swap で brick することを防ぐ。）
7. `localTokens[fromToken].depositedPCEToken >= movedPceAmount` を検証; さもなくば `"Insufficient deposited PCE token reserve at source community"` で revert（MUST）。
8. `localTokens[fromToken].depositedPCEToken` を `movedPceAmount` 分減らす。
9. `localTokens[toToken].depositedPCEToken` を `movedPceAmount` 分増やす。
10. `DepositTransferredOnInterCommunitySwap(fromToken, toToken, fromDisplayAmount, movedPceAmount)` を発行。
11. `movedPceAmount` を返す。

**修正後の `PCECommunityToken.swapTokens`:**

```solidity
function swapTokens(address toTokenAddress, uint256 amountToSwap) public {
    address sender = _msgSender();
    updateFactorIfNeeded();
    PCEToken pceToken = PCEToken(pceAddress);
    pceToken.updateFactorIfNeeded();
    PCECommunityToken to = PCECommunityToken(toTokenAddress);
    to.updateFactorIfNeeded();

    require(balanceOf(sender) >= amountToSwap, "Insufficient balance");
    require(isAllowOutgoExchange(toTokenAddress), "Outgo exchange not allowed");
    require(to.isAllowIncomeExchange(address(this)), "Income exchange not allowed");

    uint256 targetTokenAmount = TokenValueOps.computeSwapAmount(
        pceAddress, address(this), toTokenAddress, amountToSwap, getCurrentFactor(), to.getCurrentFactor()
    );
    super._burn(sender, displayBalanceToRawBalance(amountToSwap));

    // PIP-17: PCEToken が destination 側 mint と預金移動を原子的に実行する。
    // PCECommunityToken.mint が pceAddress に gate されているため、PCEToken 経由での
    // 委譲が必要（同時に PIP-17 以前の swapTokens の latent バグも解消する）。
    pceToken.executeInterCommunitySwap(
        address(this), toTokenAddress, sender, amountToSwap, targetTokenAmount
    );
}
```

旧 `to.mint(sender, targetTokenAmount)` を削除し、`pceToken.executeInterCommunitySwap(...)` 呼び出しに置き換える。これが mint と預金移動を原子的に実行する。

#### Authority（権限）

`executeInterCommunitySwap` は `swapFeeFromLocalToken` と同じパターンに従う: 当該 call が関係する登録済みコミュニティトークンインスタンスのみが呼び出し可能（`msg.sender == fromToken`）。ガバナンスロールもコミュニティオーナーロールも関与しない。EOA、汎用マルチシグ、source コミュニティトークン以外のいかなるコントラクトからも呼び出せない。

コミュニティ毎の opt-out は存在しない: `PCECommunityToken.swapTokens` 経由のすべての直接コミュニティ間 swap は預金移動を実行する。これは意図的 — 暗黙の opt-out は本 PIP が解消しようとしている直接経路と間接経路の経路ズレを再導入する。

### Rationale（設計根拠）

**なぜグローバルプールではなくコミュニティプールモデルか？**
別提案として、コミュニティ毎の預金会計を単一グローバルプールに統合し、`swapFromLocalToken` からコミュニティ毎チェックを撤廃して swap-back 検証を `balanceOf(address(this))` に対して行う設計が検討された。レビューの結果、プロトコルはコミュニティ毎会計を維持することを選択した。グローバルプール設計が失う 3 つのプロパティを保持するため: (a) コミュニティ間のクロスサブシディが境界づけられる — A の預金が B の swap-back に暗黙裏に使われない; (b) コミュニティ単位でのガバナンス推論が扱える — コミュニティの預金値が見た目の意味を保つ; (c) コミュニティ毎の swap-back 失敗が、適切な帰属単位で under-collateralization を可視化する。PIP-17 は、コミュニティ毎モデルを **捨てずに** 直接 A→B swap が引き起こす特定のドリフトを解消する最小変更。

**なぜ PCECommunityToken からの直接ストレージ操作ではなく、PCEToken に新関数を置くのか？**
`localTokens` は PCEToken の内部会計ステート。PCEToken にこのステートを変更させたいコミュニティトークンの既存パターンは、`msg.sender == fromToken` でゲートされた PCEToken 関数を呼ぶこと（`swapFeeFromLocalToken`、`PCEToken.sol:321` 参照）。PIP-17 は同じパターンに従う。クロスコントラクトのストレージ直接書き込みは既存アーキテクチャの機能ではなく、`localTokens` をコミュニティトークンから書き込み可能にするか、レジストリを複製する必要がある — どちらも確立されたパターンを再利用するより悪い。

**なぜ source 預金の比例配分ではなく swap の PCE 換算全額を移動するか？**
比例設計（`movedPceAmount = sourceDeposit * rawShareLeaving / sourceTotalRawSupply`）も検討された。under-collateralized な source コミュニティでも revert なくコミュニティ間 swap を完了させられるプロパティがある。却下した理由: (a) destination コミュニティが必要とする準備金帰属を暗黙裏に過小表示する — destination は完全な PCE 換算 claim を持つホルダーを獲得するのに、部分的な預金移動は under-collateralization を destination 側に不可視に押し付ける; (b) `swapFromLocalToken` の厳密な「預金は claim をカバーしなければならない」セマンティクスから逸脱し、PIP-17 が確立しようとしている経路等価性を壊す; (c) under-collateralized な source での revert は正しい可視化動作 — 間接経路 `swapFromLocalToken → swapToLocalToken` を使った場合に起こるのと同じ。

**なぜ burn / mint の前ではなく後に `executeInterCommunitySwap` を呼ぶのか？**
順序は計算される `movedPceAmount` に影響しない（式は `fromDisplayAmount` と source コミュニティの `exchangeRate` / `getCurrentFactor()` に依存し、いずれも burn / mint で変わらない）。burn / mint の後に呼ぶことで `swapTokens` 本体の既存構造を保ち、預金移動 call を最後のステップとして付加できる。call が revert（source 預金不足）した場合、burn / mint を含むトランザクション全体が revert し、ユーザーの残高は変化しない。これが望ましい原子性。

**なぜコミュニティ間 swap に対する新規日次上限会計を追加しないのか？**
コミュニティ間 swap は現状 `swappedToPCEToday`（コミュニティ毎の日次 swap-to-PCE 上限）を消費せず、PIP-17 もこれを変更しない。日次上限はプロトコル外への PCE 流出を絞るために設計されたものであり、コミュニティ間の内部 claim 移動を絞るためではない。コミュニティ間 swap に上限を消費させるのは分離可能なスコープ判断; *Notes* 参照。

**なぜコミュニティ毎の opt-out を持たないのか？**
預金移動を無効化するコミュニティ毎フラグは、本 PIP が解消するドリフトを設定依存の形で再導入する。移動は必須。

### Backwards Compatibility（後方互換性）

public surface での変更はすべて追加的:

- PCEToken: 新 external 関数 1 個（`executeInterCommunitySwap`）、新イベント 1 個（`DepositTransferredOnInterCommunitySwap`）。既存関数シグネチャ変更なし。ストレージレイアウト変更なし（既存スロットのみ変更）。
- PCECommunityToken: `swapTokens` の public シグネチャ、引数、可視性は変更しない。関数本体の最後に PCEToken への call が 1 つ追加される。新ストレージなし。
- `swapFromLocalToken`, `swapToLocalToken`, `swapFeeFromLocalToken`, ARIGATO CREATION ミントロジック、減衰ロジック、いかなる view 関数も変更しない。

`getDepositedPCETokens(community)` は引き続き `localTokens[community].depositedPCEToken` を返す。PIP-17 後、戻り値は補正された会計を反映する（つまり、コミュニティ間 swap の効果を含む）。この view に依存するオフチェーンリーダーは、今後はより正確なコミュニティ毎預金を観測する。PIP-17 以前のドリフトの遡及移行はない: 既存のオンチェーンステートを新たな起点とし、会計は今後のコミュニティ間 swap を通じてのみ動く。

既存の間接経路（`swapFromLocalToken` → `swapToLocalToken`）は従来通り正確に動作する。`localTokens[*].depositedPCEToken` 上の事後状態はすでに正しかった; PIP-17 は直接経路に同じ事後状態を生成させる。

`swapTokens` を呼ぶ既存スクリプト、マルチシグバッチ、ガバナンス提案は変更なく実行される。外部から見える唯一の差は、source コミュニティの `depositedPCEToken` が swap 量の PCE 換算未満のとき、コミュニティ間 swap が revert するようになる点（以前は静かに成功していた）。これが意図したセマンティクス補正。

### Test Cases（テストケース）

すべてのケースで INITIAL_FACTOR = 10^18、注記なき限り exchange rate と current factor は 1e18、BP_BASE = 10,000。

**ケース 1: 標準的なコミュニティ間 swap。**
- 設定: コミュニティ A と B、両方登録済み。`localTokens[A].depositedPCEToken = 100e18`、`localTokens[B].depositedPCEToken = 50e18`。`A.exchangeRate = 1e18`、両 current factor = 1e18、`pceToken.lastModifiedFactor = 1e18`。ユーザーは A の display 30 単位を保有。
- 操作: ユーザーが `A.swapTokens(B, 30e18)` を呼ぶ。
- 結果: A は raw 30e18 を burn、B は `targetTokenAmount` を raw でユーザーに mint。PCEToken: `localTokens[A].depositedPCEToken = 70e18`、`localTokens[B].depositedPCEToken = 80e18`。イベント `DepositTransferredOnInterCommunitySwap(A, B, 30e18, 30e18)` が発行される。

**ケース 2: 直接経路と間接経路が一致。**
- 設定: ケース 1 と同一。
- 操作 2a（間接）: ユーザーが `pceToken.swapFromLocalToken(A, 30e18)` を呼んで `pceToken.swapToLocalToken(B, 30e18)` を呼ぶ。
- 操作 2b（直接）: 同じ初期状態から、ユーザーが `A.swapTokens(B, 30e18)` を呼ぶ。
- 結果: 2 つの操作の事後状態 `localTokens[A].depositedPCEToken` と `localTokens[B].depositedPCEToken` が等しい。（PIP-17 前はこれが成立しなかった。）

**ケース 3: source 預金不足で revert。**
- 設定: `localTokens[A].depositedPCEToken = 5e18`、それ以外はケース 1 と同じ。ユーザーは A の display 30 単位を保有（ARIGATO CREATION 累積で預金を超えて供給が膨張した結果として保有）。
- 操作: ユーザーが `A.swapTokens(B, 30e18)` を呼ぶ。
- 結果: revert (`"Insufficient deposited PCE token reserve at source community"`)。ユーザーの A 残高と B の供給は不変。注: 同操作を `swapFromLocalToken(A, 30e18)` 経由で行っても `"Insufficient deposited PCE token reserve"` で revert する — 動作が 2 経路間で揃った。

**ケース 4: 権限チェック。**
- EOA、汎用コントラクト、または A 以外のコミュニティトークンが `pceToken.executeInterCommunitySwap(A, B, 10e18)` を呼ぶ。
- 結果: revert (`"Caller must be the from-side community token"`)。

**ケース 5: 同一トークンガード。**
- A が `pceToken.executeInterCommunitySwap(A, A, 10e18)` を呼ぶ（`swapTokens` の誤用等で）。
- 結果: revert (`"Same-token swap"`)。（注: `PCECommunityToken.swapTokens` は通常もっと早い段階で既存ロジックにより revert する; これは PCEToken 層での defense-in-depth チェック。）

**ケース 6: 未登録 destination。**
- B が未登録 (`localTokens[B].isExists == false`)。ユーザーが `A.swapTokens(B, 30e18)` を呼ぶ。
- 結果: `executeInterCommunitySwap` 内の最初の登録チェックで revert (`"To token not registered"`)。`B` がデプロイ済 PCECommunityToken でない場合、既存の `to.isAllowIncomeExchange(...)` 呼び出しが `swapTokens` 内でより早く失敗する; これは PCEToken 層での defense-in-depth チェック。

**ケース 7: 塵レベルの swap（PCE 換算ゼロ）。**
- 設定: `A.exchangeRate` が大きく、`mulDiv(1, INITIAL_FACTOR, A.exchangeRate)` が 0 に丸まる。
- 操作: ユーザーが `A.swapTokens(B, 1)` を呼ぶ。`executeInterCommunitySwap` が `movedPceAmount == 0` を計算。
- 結果: 預金ストレージは不変。イベント `DepositTransferredOnInterCommunitySwap(A, B, 1, 0)` が発行される。外側の `swapTokens` の `targetTokenAmount > 0` チェック（`TokenValueOps.computeSwapAmount` から継承）が swap 層でこのケースの発生を通常防ぐ; `executeInterCommunitySwap` 内のゼロ処理は防御的。

**ケース 8: 複数のコミュニティ間 swap がプロトコル全体預金合計を保つ。**
- 設定: 任意の登録済みコミュニティ、預金、ユーザーの組み合わせ。
- 操作: 任意の `A.swapTokens(B, x)` の呼び出しシーケンス。
- 不変条件: `すべての登録済みコミュニティに対する localTokens[c].depositedPCEToken の総和` がコミュニティ間 swap で不変。（PIP-17 は source と destination の間で再分配するが、預金会計を mint も burn もしない。）

### Security Considerations（セキュリティ考慮事項）

**リエントランシー。** `executeInterCommunitySwap` は PCEToken のストレージ（`localTokens[fromToken].depositedPCEToken`、`localTokens[toToken].depositedPCEToken`）への書き込み、exchange rate / current factor の読み取り、イベント発行のみを行う。`updateFactorIfNeeded()`（外部 call のない既存の PCEToken 内部関数）と `PCECommunityToken(fromToken).getCurrentFactor()`（登録済みコミュニティトークンへの `view` call）を呼ぶ。唯一の外部 call は `getCurrentFactor` への `view`。`fromToken == msg.sender` が強制され、`msg.sender` は既に実行中であるため、`swapTokens` がすでに公開している以上の新規リエントランシー面はない。実装は state mutation について checks-effects-interactions 順序に従うべき（SHOULD）。

**呼び出し元権限。** `msg.sender == fromToken` チェックは、`fromToken` が登録済みコミュニティトークンであることを前提とし、これが `localTokens[fromToken].isExists` チェックで確認される。攻撃者は預金を吸い上げるためにコミュニティトークンに偽装する任意のコントラクトをデプロイできない（レジストリメンバーシップチェックが強制される）ため。destination 側の `localTokens[toToken].isExists` チェックは未登録アドレスへの預金会計の流入を防ぐ。

**source の under-collateralization が正しく可視化される。** PIP-17 前は、ユーザーが直接 `swapTokens(B, ...)` 経由で深く under-collateralized な A を退出できた（経路がすべての預金チェックをバイパスしていたため）。PIP-17 後、この経路は revert し、間接経路の動作と一致する。これはハードニング: under-collateralized なコミュニティからの暗黙の脱出経路を取り除く。コミュニティとユーザーは、under-collateralized な source からの直接コミュニティ間 swap が失敗することを認識すべき（SHOULD）。

**フロントランニングと順序。** ユーザーが mempool 内の `swapTokens(B, large)` を観測し、`swapFromLocalToken(A, large)` でフロントランすると、A の預金を枯渇させ、保留中の直接 swap を revert させ得る。PIP-17 前は、direct swap は無関係に成功していた。これは新しい攻撃ベクトルではない — `swapFromLocalToken` はすでに A の預金に対して先着順 — が、コミュニティ間 swap にも拡張される。緩和策は通常の swap-back と同じ: ブロック毎のトランザクション順序と既存の日次 swap 上限に依拠する。

**整数演算。** `movedPceAmount` の式は `Math.mulDiv` を使ってオーバーフローに対して安全に mulDiv-then-divide を行い、精度損失を避ける。実装は `Math.mulDiv`（または同等）を使用しなければならない（MUST）。素朴な `(a * b) / c` を使ってはならない（MUST NOT）。

**コントラクト間信頼。** `executeInterCommunitySwap` の権限モデルは、`localTokens[*].isExists` が PCECommunityToken コントラクトに準拠したコードのみに対して設定されていることに依存する（つまりレジストリが信頼境界）。準拠しないコードをレジストリに追加することはガバナンス障害であり本 PIP のスコープ外、かつシステムの他の多くの部分を既に壊す。PIP-17 はこの面で新たなリスクを導入しない。

**オフチェーン会計のためのイベントカバレッジ。** `DepositTransferredOnInterCommunitySwap` は成功した移動ごとに発行される（`movedPceAmount == 0` の short-circuit を含む）。オフチェーンインデクサは、コミュニティ間預金移動の単一の真実の源としてこのイベントに依拠でき、コミュニティトークン自体上の `Transfer` 相当の burn / mint と照合できる。

### Notes

- **本提案が保証すること:** `PCECommunityToken.swapTokens(toToken, amount)` 経由のすべての直接コミュニティ間 swap について、`PCEToken.localTokens[*].depositedPCEToken` 上のコミュニティ毎 PCE 預金会計が、間接 A→PCE→B 経路と整合的に原子的に更新される。すべての登録済みコミュニティに対する `sum localTokens[c].depositedPCEToken` の総和はコミュニティ間 swap で不変。
- **本提案が保証しないこと:**
  - コミュニティ毎の預金が常時コミュニティ毎の claim をカバーすること。ARIGATO CREATION ミントは引き続きコミュニティトークンの claim を膨張させるが預金は増やさず、PCE BASE Token の減衰は引き続き claim を侵食するが預金は変えない。両効果はスコープ外で既存準備金モデルの特性。
  - under-collateralized な source からのコミュニティ間 swap が成功すること。当該 swap は revert する（ケース 3）。これが意図したハードニング。
  - 日次 swap 上限の何らかの変更。コミュニティ間 swap は引き続き `swappedToPCEToday` で制約されない。
- **スコープ外:**
  - コミュニティ間 swap をコミュニティ毎の日次 swap-to-PCE 上限の消費として扱うこと。分離可能な設計判断; 進める場合、`swapTokens` から明示的な `recordSwapToPCE` 様 call を追加する後続 PIP とすべき。
  - PIP-17 以前の預金ドリフトのバックフィル。アップグレード時点のオンチェーンステートが新たな基準値; 履歴ドリフトの修正にはオフチェーン分析と一回限りのガバナンス reconciliation トランザクションが必要で、両方とも分離可能。
  - コミュニティ毎準備金モデルのグローバルプールへの再構成、または `swapFromLocalToken` の預金チェックに関する関連変更。コミュニティ毎会計の保持を優先して検討の上明示的に却下。
- **依存:** なし。PIP-17 は現行 `peacecoin-protocol/core` コードベース上で実装可能（PIP-14 の所有権セマンティクスがアクティブな場合はそれと整合するが、PIP-14 への機能的依存はない）。
- **実装リファレンス:** `peacecoin-protocol/core` — 影響を受けるファイルは `src/PCEToken.sol`（新関数とイベント）と `src/PCECommunityToken.sol`（`swapTokens` 末尾への 1 行追加）。ライブラリ変更なし（`src/lib/ArigatoCreation.sol`, `src/lib/TokenValueOps.sol`, `src/lib/TokenSetting.sol` には触れない）。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
