### PR TITLE
PIP-18: ARIGATO CREATION Cross-Community Neutralization via Protocol-wide Daily Mint Limit

### DIFF
--- a/PIPs/pip-18.md
+++ b/PIPs/pip-18.md
@@ -1,0 +1,223 @@
+---
+pip: 18
+title: ARIGATO CREATION Cross-Community Neutralization via Protocol-wide Daily Mint Limit
+proposer: CHIBA Masahiro (@nihen)
+status: Draft
+type: Core
+created: 2026-05-01
+requires: []
+replaces: []
+---
+
+## PIP-18: ARIGATO CREATION Cross-Community Neutralization via Protocol-wide Daily Mint Limit
+
+### Abstract
+
+This proposal moves the `maxIncreaseOfTotalSupplyBp` parameter — which caps the daily ARIGATO CREATION mint volume of each community as a fraction of that community's midnight total supply — from per-community storage to a single protocol-wide value managed by PCE governance. After this change, the daily mint cap of every community is a fixed fraction of its own backing value (PCE BASE Token), so no community can grant itself a structurally larger PCE-equivalent issuance ceiling than another. Per-transaction parameters that shape *how* mints are distributed inside a community (`maxIncreaseBp`, `maxUsageBp`, `changeBp`) remain under each community's control.
+
+### Motivation
+
+PCE protocol invariants make the relationship between PCE Token and Community Token neutral with respect to community choice in nearly all dimensions:
+
+- **PCE Token holdings** do not decay with time.
+- **Community Token decay** affects only the *display balance*; the underlying PCE BASE Token (the swap-back claim, expressed in PCE) is not eroded by the community's own decay schedule.
+- **Dilution factor** is reversibly cancelled out across `swapToLocalToken` / `swapFromLocalToken`, so it is purely a denomination choice.
+- **Time decay of PCE BASE Token** is a single global rule applied to every community equally.
+
+The remaining non-neutrality is **ARIGATO CREATION**. Today each community sets its own `maxIncreaseOfTotalSupplyBp`, which determines the per-day cap on additional Community Token minted as transfer rewards. Because this cap is denominated as a fraction of the community's own midnight supply (whose PCE-equivalent is the community's PCE BASE Token total), a community that picks a larger value can grant itself a structurally larger daily issuance ceiling per unit of backing value. From the protocol's point of view this is the only mechanism whose PCE-equivalent cap is not anchored to a single rule.
+
+This proposal closes that gap by making `maxIncreaseOfTotalSupplyBp` a protocol-wide parameter set by governance. Everything else about ARIGATO CREATION — the per-transaction reward shape, how individual users are rewarded — remains in each community's hands as part of its local distribution policy.
+
+### Specification
+
+#### Overview
+
+- A new state variable `maxIncreaseOfTotalSupplyBp` on `PCEToken` becomes the **only** value consulted when computing the daily mint cap inside `ArigatoCreation.compute`.
+- The existing `TokenSetting.maxIncreaseOfTotalSupplyBp` field on each `PCECommunityToken` remains in storage (storage-layout safety) and continues to be settable through `setTokenSettings` for ABI compatibility, but is no longer read by mint logic. It becomes inert data.
+- The protocol-wide value MUST be initialized in the same transaction as the upgrade. A value of `0` halts ARIGATO CREATION minting in every community (this is the existing behaviour when a community's per-community value is `0`).
+
+#### PCEToken — new state variable
+
+```solidity
+/// @notice Protocol-wide cap on daily ARIGATO CREATION mint volume,
+///         expressed as basis points of each community's midnight total supply.
+///         Replaces the per-community `TokenSetting.maxIncreaseOfTotalSupplyBp`.
+uint16 public maxIncreaseOfTotalSupplyBp;
+```
+
+`maxIncreaseOfTotalSupplyBp` is initialized to `0` by storage default and MUST be set by governance in the upgrade transaction (see *Upgrade procedure* below).
+
+#### PCEToken — new function
+
+```solidity
+/// @notice Set the protocol-wide ARIGATO CREATION daily-mint cap, in basis points.
+/// @dev    Only callable by the contract owner (PCE governance / Timelock).
+///         Emits `MaxIncreaseOfTotalSupplyBpSet`.
+/// @param  newValue New cap in basis points. MUST be `<= 10000` (i.e. `<= 100%`).
+function setMaxIncreaseOfTotalSupplyBp(uint16 newValue) external onlyOwner;
+```
+
+Behaviour:
+
+1. `require(newValue <= 10000, "Bp <= 10000")`.
+2. Cache `oldValue = maxIncreaseOfTotalSupplyBp`.
+3. Assign `maxIncreaseOfTotalSupplyBp = newValue`.
+4. Emit `MaxIncreaseOfTotalSupplyBpSet(oldValue, newValue)`.
+
+The new value takes effect on the next ARIGATO CREATION mint call in any community.
+
+#### PCEToken — new event
+
+```solidity
+event MaxIncreaseOfTotalSupplyBpSet(uint16 oldValue, uint16 newValue);
+```
+
+Emitted whenever `setMaxIncreaseOfTotalSupplyBp` is called. The event is emitted unconditionally, including for no-op assignments (`oldValue == newValue`), so off-chain observers see every governance call.
+
+#### PCECommunityToken — mint-path change
+
+The internal call site that builds `ArigatoCreation.Params` (currently `_mintArigatoCreation` in `src/PCECommunityToken.sol`) MUST replace its `TokenSetting.maxIncreaseOfTotalSupplyBp` reference with the value read from `PCEToken`:
+
+```solidity
+// before:
+//   maxIncreaseOfTotalSupplyBp: maxIncreaseOfTotalSupplyBp,
+// after:
+//   maxIncreaseOfTotalSupplyBp: PCEToken(pceAddress).maxIncreaseOfTotalSupplyBp(),
+```
+
+`ArigatoCreation.compute` itself is unchanged. The `TokenSetting.maxIncreaseOfTotalSupplyBp` field is no longer consulted by any mint-path code after this change.
+
+#### PCECommunityToken — settings ABI (unchanged)
+
+`createToken(...)`, `setTokenSettings(...)` and `getTokenSettings(...)` continue to accept and return a `maxIncreaseOfTotalSupplyBp` field at the same position. The value is still stored to preserve the existing storage layout, but is no longer used in any computation. Communities and operators MAY continue to write any value to this field; doing so has no effect on the daily mint cap.
+
+#### Algorithms (full mint cap)
+
+After this change, the global daily mint cap of community `c` is computed inside `ArigatoCreation.compute` as:
+
+```
+maxArigatoCreationMintToday(c) =
+    midnightTotalSupply(c) × PCEToken.maxIncreaseOfTotalSupplyBp() / 10_000
+```
+
+All downstream caps (`maxArigatoCreationMintTodayForGuest = ÷10`, the per-sender share derived from `accountInfo.midnightBalance / midnightTotalSupply`, and the flat 1% guest-sender cap) follow unchanged from this base, so they automatically scale with the new global value.
+
+The PCE-equivalent of `midnightTotalSupply(c)` is community `c`'s PCE BASE Token total. With a single protocol-wide `maxIncreaseOfTotalSupplyBp`, every community's daily mint cap is the same fraction of its own PCE BASE Token total, eliminating the only remaining cross-community non-neutrality on this dimension.
+
+#### Upgrade procedure
+
+The PCEToken and PCECommunityToken implementation upgrades MUST be performed atomically with the initial value setup. The single upgrade proposal MUST contain, in order:
+
+1. Upgrade PCEToken implementation (UUPS) to the new version that adds `maxIncreaseOfTotalSupplyBp` and `setMaxIncreaseOfTotalSupplyBp`.
+2. Upgrade PCECommunityToken implementation (Beacon) to the new version that reads `PCEToken.maxIncreaseOfTotalSupplyBp()` in the mint path.
+3. Call `PCEToken.setMaxIncreaseOfTotalSupplyBp(initialValue)` with the governance-decided initial value.
+
+If steps 1 and 2 ship without step 3, the protocol-wide cap is `0` and every community's ARIGATO CREATION halts. Implementations MUST NOT split the proposal across separate transactions.
+
+#### Storage layout
+
+- `PCEToken`: append `uint16 maxIncreaseOfTotalSupplyBp` to the end of the existing storage layout. No reordering or removal of existing slots.
+- `PCECommunityToken` (and inherited `TokenSetting`): no storage layout changes. The deprecated `TokenSetting.maxIncreaseOfTotalSupplyBp` field stays in place.
+
+### Rationale
+
+**Why move only `maxIncreaseOfTotalSupplyBp`, not the other ARIGATO CREATION parameters?**
+`maxIncreaseOfTotalSupplyBp` is the only ARIGATO CREATION parameter that determines a community's *daily issuance ceiling* in PCE-equivalent terms. The remaining parameters (`maxIncreaseBp`, `maxUsageBp`, `changeBp`) shape *how* the daily budget is distributed across individual transfers (which usage patterns earn higher reward, how strongly off-target usage is penalized). Those are local distribution-policy choices that legitimately differ from one community to another. Centralizing only the ceiling preserves community design freedom while removing the protocol-level inequity.
+
+**Why protocol-wide rather than per-community-with-a-cap?**
+A per-community cap with a global maximum (e.g. "each community sets its own value, capped at `globalMax`") would technically bound the divergence but would still allow communities to differentiate their structural ceilings up to the cap. The neutrality goal is exact equality of the *ratio* — same fraction of backing value across all communities — which only a single shared value provides.
+
+**Why anchor the cap to `midnightTotalSupply` (PCE BASE Token total) rather than `depositedPCEToken`?**
+`midnightTotalSupply` reflects the community's full backing value — actual locked PCE plus the PCE-equivalent claim created by accumulated ARIGATO CREATION mints. `depositedPCEToken` only tracks the actually-locked PCE and diverges from backing value over time as ARIGATO CREATION accumulates and inter-community swaps move PCE around. Anchoring the cap to backing value matches what the PIP is trying to neutralize (PCE-equivalent issuance ceiling per unit of backing). Anchoring to `depositedPCEToken` would couple the cap to factors unrelated to the protocol's neutrality goal (e.g. the recent history of withdrawals would shrink a community's cap even when its claims have not changed).
+
+**Why keep the deprecated per-community field in storage?**
+Removing the storage slot would break the upgrade-safe storage layout of `PCECommunityToken`. Keeping the slot — and its setter/getter ABI — has no on-chain cost beyond the unused storage write that already happens, and it lets existing tools that read `getTokenSettings()` keep working unchanged.
+
+**Why require atomic initialization with the upgrade?**
+A new `uint16` defaults to `0`. With `maxIncreaseOfTotalSupplyBp == 0`, `ArigatoCreation.compute` returns `(0, _)` for every call, halting ARIGATO CREATION minting across every community. Splitting initialization into a follow-up transaction would create a mint outage between deployment and the second transaction. Bundling both into one governance proposal is the only safe option.
+
+**Why not bound `setMaxIncreaseOfTotalSupplyBp` more tightly than `<= 10000`?**
+The current per-community field is a `uint16` with the same `<= 10000` semantics implied by the BP convention. Introducing a tighter bound (e.g. `<= 500` for "max 5%") would freeze a value-judgement into the contract that governance can already enforce. The `<= 10000` bound is purely a sanity check that the value fits a basis-point interpretation.
+
+### Backwards Compatibility
+
+**Behavioural changes:**
+
+- The per-community `maxIncreaseOfTotalSupplyBp` value stored in each community's `TokenSetting` storage is no longer consulted when computing the daily mint cap. Communities whose previous local value differed from the new protocol-wide value will see their effective daily cap change immediately at upgrade.
+- Tooling that surfaces "this community's daily mint cap" must read `PCEToken.maxIncreaseOfTotalSupplyBp()` instead of the per-community value. Reading the per-community field still returns the previously stored number, but that number no longer drives mint behaviour.
+
+**Non-breaking:**
+
+- `createToken`, `setTokenSettings`, and `getTokenSettings` retain the same signatures, parameter order, and returned tuple. Existing scripts and frontends do not need ABI changes. Pass-through values are stored but do not affect mint logic.
+- Per-transaction reward shaping (`maxIncreaseBp`, `maxUsageBp`, `changeBp`) is unchanged. Communities continue to set these locally.
+- Decay (`afterDecreaseBp`, `decreaseIntervalDays`), swap (`swapFromLocalToken`, `swapToLocalToken`, `swapTokens`), `Transfer`, allowance, voucher, and EIP-3009 paths are not modified.
+- PCEToken storage layout is extended only by appending one new slot. PCECommunityToken storage layout is unchanged.
+
+### Test Cases
+
+All examples below assume `BP_BASE = 10_000` and a freshly-upgraded protocol where governance has set `PCEToken.maxIncreaseOfTotalSupplyBp = 100` (i.e. 1%). All Community Token amounts are raw (pre-factor-multiplication) values to match `midnightTotalSupply`.
+
+**Case 1: Two communities of equal size and equal cap ratio**
+- Community A: `midnightTotalSupply = 10_000 ether`
+- Community B: `midnightTotalSupply = 10_000 ether`
+- Both communities' previously-stored per-community `maxIncreaseOfTotalSupplyBp` was different (A: 100, B: 50). After upgrade, both are read from PCEToken (= 100).
+- `maxArigatoCreationMintToday(A) = 100 ether`, `maxArigatoCreationMintToday(B) = 100 ether`
+- Result: identical caps across communities. The previously divergent local values no longer have any effect.
+
+**Case 2: Communities of different sizes, same cap ratio**
+- Community A: `midnightTotalSupply = 10_000 ether` (PCE BASE Token total ≈ 10_000 PCE)
+- Community B: `midnightTotalSupply = 1_000 ether` (PCE BASE Token total ≈ 1_000 PCE)
+- `maxArigatoCreationMintToday(A) = 100 ether (≈ 100 PCE worth)`
+- `maxArigatoCreationMintToday(B) = 10 ether (≈ 10 PCE worth)`
+- Result: same fraction of backing value (1%) per community.
+
+**Case 3: Governance changes the cap**
+- Initial state: `PCEToken.maxIncreaseOfTotalSupplyBp = 100` (1%)
+- Governance executes `setMaxIncreaseOfTotalSupplyBp(50)` (0.5%)
+- Event: `MaxIncreaseOfTotalSupplyBpSet(100, 50)`
+- Next ARIGATO CREATION mint in any community uses the new 0.5% cap.
+- No state change in any `PCECommunityToken` is required.
+
+**Case 4: Cap of 0 halts minting**
+- `PCEToken.maxIncreaseOfTotalSupplyBp = 0`
+- Any transfer that would normally trigger ARIGATO CREATION still completes normally as a transfer; the additional mint amount is `0`.
+- This matches today's behaviour when a community's local `maxIncreaseOfTotalSupplyBp == 0`.
+
+**Case 5: Per-community field still settable but inert**
+- Owner of community A calls `setTokenSettings(..., maxIncreaseOfTotalSupplyBp = 5_000, ...)` (i.e. 50%).
+- The value is written to community A's storage; `getTokenSettings()` reflects it.
+- A subsequent transfer in community A still mints under the protocol-wide cap (e.g. 1% if PCEToken's value is 100). The local 50% value has no effect.
+
+**Case 6: Reverts on out-of-range input**
+- Governance executes `setMaxIncreaseOfTotalSupplyBp(10_001)`.
+- The call MUST revert with `"Bp <= 10000"`.
+
+**Case 7: Non-governance caller cannot set the cap**
+- Any non-owner address calls `setMaxIncreaseOfTotalSupplyBp(50)`.
+- The call MUST revert (OpenZeppelin `OwnableUnauthorizedAccount` error).
+
+### Security Considerations
+
+**Centralization of cap control**: After this PIP, the daily mint ceiling of every community is set by a single governance-controlled value. This is by construction — the goal of the PIP is to remove a per-community degree of freedom. The standard PCE governance protections (Timelock delay between proposal and execution, on-chain quorum and voting period set by the Governor) constrain abrupt or hostile changes. Implementations SHOULD ensure the Timelock delay is sufficient for communities to react to a proposed change.
+
+**Atomic-initialization invariant**: As noted under *Upgrade procedure*, splitting the upgrade and the initial `setMaxIncreaseOfTotalSupplyBp` call into separate transactions causes a protocol-wide mint outage between them. Governance MUST bundle both into a single proposal. The proposal text SHOULD explicitly include the initial value so reviewers can verify it.
+
+**Read path coupling**: `PCECommunityToken._mintArigatoCreation` now performs an external `STATICCALL` to `PCEToken` for every transfer that triggers ARIGATO CREATION. This adds approximately one extra cold storage read of cost to mint-eligible transfers, paid by the relayer (for meta-transactions) or the sender (for direct transfers). The cost is negligible relative to the existing ERC-20 transfer and ARIGATO CREATION accounting.
+
+**Frontrunning the cap-change**: A user observing a pending governance proposal that lowers `maxIncreaseOfTotalSupplyBp` could attempt to execute mint-eligible transfers ahead of the change to consume more of the old higher cap. This is identical in shape to current behaviour where a community owner could lower the local value, and is bounded by the per-day cap itself (the user cannot mint more than today's cap regardless). No additional on-chain protection is proposed; implementations MAY surface upcoming changes off-chain.
+
+**Reverse migration**: This PIP does not provide a path back to per-community `maxIncreaseOfTotalSupplyBp`. If a future PIP wants per-community values to govern again, it would need to introduce a separate read switch and reverse the mint-path change. The deprecated storage slot is preserved precisely to keep this option open without further upgrade-safety risk.
+
+### Notes
+
+- **Scope of impact**: PCEToken (UUPS) and PCECommunityToken (Beacon) both require an upgrade. No community-level migration script is required beyond the bundled `setMaxIncreaseOfTotalSupplyBp` call.
+- **Not in scope**: Choosing the initial value of `maxIncreaseOfTotalSupplyBp` and the cadence at which governance reviews it. Both are governance decisions to be made alongside this PIP's adoption (see *Open governance decisions* below).
+- **Not in scope (cross-community neutrality, individual level)**: This PIP does not equalize per-transfer reward rates across communities. Differences in `maxIncreaseBp`, `maxUsageBp`, and `changeBp` continue to make the same transfer earn different ARIGATO CREATION amounts in different communities. That is treated as a community-internal distribution policy and explicitly retained.
+- **Not in scope (PCE BASE Token vs `depositedPCEToken`)**: The structural divergence between PCE BASE Token total (the conceptual backing value) and `depositedPCEToken` (the actually-locked PCE) is a separate, longer-running concern not addressed here. This PIP anchors the cap to `midnightTotalSupply` (which corresponds to PCE BASE Token), so its neutrality property holds independently of how `depositedPCEToken` evolves.
+- **Open governance decisions** (to be made alongside adoption):
+  1. The initial value of `maxIncreaseOfTotalSupplyBp` (likely informed by a survey of currently configured per-community values).
+  2. The review cadence and the metrics governance will consult before changing it.
+  3. Communication to existing community operators about the deprecation of the per-community setting.
+- **Related repos**: [peacecoin-protocol/core](https://github.com/peacecoin-protocol/core), [peacecoin-protocol/PIPs](https://github.com/peacecoin-protocol/PIPs).
+- **Source document**: <https://github.com/nihen/nihen.github.io/blob/main/peacecoin-protocol/arigato-neutrality/README.md>
+- **Dependencies**: None. Compatible with PIP-13, PIP-15, PIP-16, PIP-17 storage and ABI.


### PR DESCRIPTION
## Summary

- Add PIP-18: ARIGATO CREATION Cross-Community Neutralization via Protocol-wide Daily Mint Limit
- **PIP full text**: [PIPs/pip-18.md](https://github.com/peacecoin-protocol/PIPs/blob/pip-18/PIPs/pip-18.md)
- **Source document**: <https://github.com/nihen/nihen.github.io/blob/main/peacecoin-protocol/arigato-neutrality/README.md>

## Abstract

This proposal moves the `maxIncreaseOfTotalSupplyBp` parameter — which caps the daily ARIGATO CREATION mint volume of each community as a fraction of that community's midnight total supply — from per-community storage to a single protocol-wide value managed by PCE governance. After this change, every community's daily mint cap is the same fraction of its own backing value (PCE BASE Token), removing the only remaining cross-community non-neutrality on PCE-equivalent issuance ceilings. Per-transaction reward shaping (`maxIncreaseBp`, `maxUsageBp`, `changeBp`) remains under each community's control as local distribution policy.

### Key Points

- **Single protocol-wide cap**: New `PCEToken.maxIncreaseOfTotalSupplyBp` (uint16, governance-set) becomes the only value consulted in `ArigatoCreation.compute`.
- **Per-community field deprecated, not removed**: `TokenSetting.maxIncreaseOfTotalSupplyBp` stays in storage and remains settable through `setTokenSettings` for storage-layout and ABI compatibility, but no longer drives mint behaviour.
- **Atomic upgrade required**: PCEToken + PCECommunityToken upgrades and the initial `setMaxIncreaseOfTotalSupplyBp` call must ship in a single governance transaction; otherwise the default `0` halts ARIGATO CREATION protocol-wide.
- **Cap anchored to PCE BASE Token total** (`midnightTotalSupply`), not `depositedPCEToken` — keeps neutrality independent of swap history.
- **Scope**: Requires upgrades to both PCEToken (UUPS) and PCECommunityToken (Beacon).

## Test plan

- [ ] PIP-1 governance framework compliance (template, frontmatter, mandatory sections)
- [ ] Specification precision check (function signatures, exact mint cap formula, storage layout impact)
- [ ] 7 test cases reviewed (equal/unequal sizes, governance change, cap=0, deprecated field still settable, range / authorization reverts)
- [ ] Security considerations reviewed (centralization, atomic init invariant, gas, frontrunning, no reverse migration)

---

<details><summary>日本語版 PIP 全文</summary>

```
---
pip: 18
title: ARIGATO CREATION Cross-Community Neutralization via Protocol-wide Daily Mint Limit
proposer: CHIBA Masahiro (@nihen)
status: Draft
type: Core
created: 2026-05-01
requires: []
replaces: []
---
```

## PIP-18: ARIGATO CREATION のコミュニティ間中立化：プロトコル横断の日次ミント上限

### Abstract（要旨）

本提案は、ARIGATO CREATION の日次ミント上限を、コミュニティの夜間総供給量（PCE BASE Token 総量に対応）に対する比率として与える `maxIncreaseOfTotalSupplyBp` を、コミュニティ単位の設定から PCE ガバナンスが管理するプロトコル全体の単一値に移行する。これにより、各コミュニティの日次ミント上限は自身の裏付け価値（PCE 換算）に対して必ず同じ比率となり、コミュニティ間で「同じ裏付け価値あたりの発行ペース」が完全に揃う。送金個別の報酬計算に関わるパラメータ（`maxIncreaseBp` / `maxUsageBp` / `changeBp`）はこれまでどおり各コミュニティの裁量に残す。

### Motivation（動機）

PCE プロトコルにおいて、PCE Token と Community Token の関係は、コミュニティ選択に対してほぼ全面的に中立である:

- **PCE Token の保有残高**は時間で減衰しない。
- **Community Token の減衰**は表示残高にのみ作用し、裏付け価値である PCE BASE Token は当該コミュニティの減衰スケジュールでは目減りしない。
- **希釈率**は `swapToLocalToken` / `swapFromLocalToken` で可逆に打ち消されるため、純粋に額面の取り方の問題でしかない。
- **PCE BASE Token の時間減衰**はプロトコル全体に均一に適用される単一ルールである。

唯一の例外が **ARIGATO CREATION** である。現在は各コミュニティが `maxIncreaseOfTotalSupplyBp` を独自に設定する。この上限はコミュニティ自身の夜間総供給量（PCE 換算は当該コミュニティの PCE BASE Token 総量）に対する比率なので、より大きな値を採用したコミュニティは「同じ裏付け価値に対してより大きな日次発行枠」を構造的に自分に与えられる。プロトコル視点で見ると、PCE 換算の上限が単一ルールに紐付いていない唯一のメカニズムが ARIGATO CREATION である。

本提案は `maxIncreaseOfTotalSupplyBp` をガバナンス管理のプロトコル横断パラメータに移すことでこの差を解消する。ARIGATO CREATION のうち送金個別の報酬形状や個人ユーザーへの分配ロジックは、コミュニティ内部の分配施策として各運営者の裁量に残す。

### Specification（仕様）

#### Overview（全体像）

- `PCEToken` に新しい状態変数 `maxIncreaseOfTotalSupplyBp` を追加し、`ArigatoCreation.compute` における日次ミント上限算出ではこの値**だけ**を参照する。
- 既存の `TokenSetting.maxIncreaseOfTotalSupplyBp`（コミュニティ単位）は storage layout 互換のためフィールドを残し、`setTokenSettings` の ABI 互換のため引き続き設定可能だが、ミントロジックからは参照されなくなる（事実上の deprecated データ）。
- プロトコル横断値はアップグレードと同一トランザクション内で初期化 MUST。値が `0` の場合、全コミュニティで ARIGATO CREATION ミントが停止する（これは現在 per-community 値が `0` のときと同じ挙動）。

#### PCEToken — new state variable（新しい状態変数）

```solidity
/// @notice Protocol-wide cap on daily ARIGATO CREATION mint volume,
///         expressed as basis points of each community's midnight total supply.
///         Replaces the per-community `TokenSetting.maxIncreaseOfTotalSupplyBp`.
uint16 public maxIncreaseOfTotalSupplyBp;
```

`maxIncreaseOfTotalSupplyBp` はストレージのデフォルトで `0` に初期化される。アップグレードトランザクション内でガバナンスが初期値を設定 MUST（後述 *Upgrade procedure* 参照）。

#### PCEToken — new function（新しい関数）

```solidity
/// @notice Set the protocol-wide ARIGATO CREATION daily-mint cap, in basis points.
/// @dev    Only callable by the contract owner (PCE governance / Timelock).
///         Emits `MaxIncreaseOfTotalSupplyBpSet`.
/// @param  newValue New cap in basis points. MUST be `<= 10000` (i.e. `<= 100%`).
function setMaxIncreaseOfTotalSupplyBp(uint16 newValue) external onlyOwner;
```

挙動:

1. `require(newValue <= 10000, "Bp <= 10000")`。
2. `oldValue = maxIncreaseOfTotalSupplyBp` を退避。
3. `maxIncreaseOfTotalSupplyBp = newValue` を代入。
4. `MaxIncreaseOfTotalSupplyBpSet(oldValue, newValue)` を emit。

新しい値はその次に行われる任意のコミュニティの ARIGATO CREATION ミント呼び出しから有効。

#### PCEToken — new event（新しいイベント）

```solidity
event MaxIncreaseOfTotalSupplyBpSet(uint16 oldValue, uint16 newValue);
```

`setMaxIncreaseOfTotalSupplyBp` 呼び出し時に必ず emit する。`oldValue == newValue` の場合も含めて無条件 emit するため、ガバナンスの全変更操作がオフチェーンで観測可能。

#### PCECommunityToken — mint-path change（ミントパス変更）

`ArigatoCreation.Params` を組み立てている呼び出し箇所（現状 `src/PCECommunityToken.sol` の `_mintArigatoCreation`）について、`TokenSetting.maxIncreaseOfTotalSupplyBp` の参照を `PCEToken` から読む値に置き換え MUST:

```solidity
// before:
//   maxIncreaseOfTotalSupplyBp: maxIncreaseOfTotalSupplyBp,
// after:
//   maxIncreaseOfTotalSupplyBp: PCEToken(pceAddress).maxIncreaseOfTotalSupplyBp(),
```

`ArigatoCreation.compute` 自体は変更不要。本変更後、`TokenSetting.maxIncreaseOfTotalSupplyBp` フィールドはミントパスのどのコードからも参照されない。

#### PCECommunityToken — settings ABI（設定 ABI、不変）

`createToken(...)` / `setTokenSettings(...)` / `getTokenSettings(...)` は引き続き同じ位置に `maxIncreaseOfTotalSupplyBp` フィールドを受け取り、返す。storage layout 維持のため値は引き続き保存されるが、いかなる計算にも使われない。コミュニティ運営者および運用ツールは引き続き任意の値を書き込み MAY だが、それは日次ミント上限に影響しない。

#### Algorithms（完全なミント上限式）

本変更後、コミュニティ `c` のグローバル日次ミント上限は `ArigatoCreation.compute` 内で次のように計算される:

```
maxArigatoCreationMintToday(c) =
    midnightTotalSupply(c) × PCEToken.maxIncreaseOfTotalSupplyBp() / 10_000
```

派生する全ての下流上限（ゲスト全体上限 = ÷10、`accountInfo.midnightBalance / midnightTotalSupply` から得られる送信者ごとのシェア、ゲスト個人の固定 1% 上限）はこのベースから不変のロジックで決まるため、新しいグローバル値に自動的にスケールする。

`midnightTotalSupply(c)` の PCE 換算はコミュニティ `c` の PCE BASE Token 総量である。`maxIncreaseOfTotalSupplyBp` をプロトコル単一値にすることで、各コミュニティの日次ミント上限は自身の PCE BASE Token 総量に対して常に同じ比率となり、本軸での唯一残っていたコミュニティ間非中立が解消される。

#### Upgrade procedure（アップグレード手順）

PCEToken と PCECommunityToken の実装アップグレード、および初期値設定はアトミックに行う MUST。単一のガバナンス提案に以下を順序通り含める MUST:

1. PCEToken 実装（UUPS）を `maxIncreaseOfTotalSupplyBp` と `setMaxIncreaseOfTotalSupplyBp` を追加した新バージョンへアップグレード。
2. PCECommunityToken 実装（Beacon）をミントパスで `PCEToken.maxIncreaseOfTotalSupplyBp()` を読む新バージョンへアップグレード。
3. ガバナンスが決定した初期値で `PCEToken.setMaxIncreaseOfTotalSupplyBp(initialValue)` を呼び出す。

ステップ 1, 2 のみ実行してステップ 3 を別トランザクションに分割すると、その間プロトコル全体で ARIGATO CREATION が停止する。実装は提案を分割しては MUST NOT。

#### Storage layout（ストレージレイアウト）

- `PCEToken`: 既存レイアウトの末尾に `uint16 maxIncreaseOfTotalSupplyBp` を追加。既存スロットの並び替え・削除なし。
- `PCECommunityToken`（および継承する `TokenSetting`）: ストレージレイアウト変更なし。deprecated 化された `TokenSetting.maxIncreaseOfTotalSupplyBp` フィールドはそのまま残す。

### Rationale（設計根拠）

**なぜ `maxIncreaseOfTotalSupplyBp` だけを移すのか？他の ARIGATO CREATION パラメータは？**
`maxIncreaseOfTotalSupplyBp` は ARIGATO CREATION パラメータの中で唯一、コミュニティの「PCE 換算での日次発行枠」を決めるパラメータである。残り（`maxIncreaseBp` / `maxUsageBp` / `changeBp`）は日次予算を個別の送金にどう配分するかを形作るパラメータ（どんな利用パターンが高報酬になるか、理想からの乖離をどれだけペナルティするか）であり、コミュニティごとに異なってよい分配施策である。上限だけを中央化することで、コミュニティの設計自由度を残しつつプロトコル水準の不公平を取り除ける。

**なぜ「上限付きの per-community 値」ではなくプロトコル横断の単一値にするのか？**
「各コミュニティが値を設定するが上限 `globalMax` までに制限する」方式でも発散は抑えられるが、上限以下では依然としてコミュニティが構造的差をつけられる。中立化の目的は「裏付け価値に対する比率が完全に等しくなる」ことであり、これは単一共有値でしか実現できない。

**なぜ上限を `midnightTotalSupply`（PCE BASE Token 総量）に紐付けるのか？`depositedPCEToken` ではなく？**
`midnightTotalSupply` はコミュニティの裏付け価値全体（実際にロックされている PCE + 累積した ARIGATO CREATION ミントが生んだ PCE 換算クレーム）を反映する。`depositedPCEToken` は実際にロックされている PCE のみを追跡し、ARIGATO CREATION 累積やコミュニティ間 swap によって裏付け価値とは時間とともに乖離する。本 PIP が中立化したいのは「裏付け価値あたりの PCE 換算発行枠」なので、紐付け先は裏付け価値が正しい。`depositedPCEToken` に紐付けると、たとえば最近 swap back が多かったコミュニティの上限がクレーム量に変化がないのに縮むことになり、本 PIP のゴールと整合しない。

**なぜ deprecated 化された per-community フィールドをストレージに残すのか？**
ストレージスロットを削除すると `PCECommunityToken` のアップグレード安全な storage layout を破壊してしまう。スロットと setter / getter ABI を残しても、すでに発生している未使用ストレージ書き込み以上のオンチェーンコストはかからず、`getTokenSettings()` を読む既存ツールが何も変更せず動き続ける利点がある。

**なぜアップグレードと同一トランザクションでの初期化が必須なのか？**
新しい `uint16` のデフォルト値は `0` である。`maxIncreaseOfTotalSupplyBp == 0` だと `ArigatoCreation.compute` は全コールで `(0, _)` を返し、全コミュニティで ARIGATO CREATION ミントが停止する。初期化を別トランザクションに切り出すと、デプロイから初期化トランザクションまでの間、ミント停止期間が生まれてしまう。両方を 1 つのガバナンス提案に束ねるのが唯一の安全な選択肢である。

**なぜ `setMaxIncreaseOfTotalSupplyBp` の上限を `<= 10000` 以上に厳しくしないのか？**
現行の per-community フィールドも `uint16` で、bp 規約から暗黙的に `<= 10000` セマンティクスを持つ。`<= 500`（最大 5% など）のような値判断をコントラクトに固定すると、本来ガバナンスが決められる経済設計の判断を凍結することになる。`<= 10000` は bp として解釈可能な値であることだけを保証するサニティチェック。

### Backwards Compatibility（後方互換性）

**挙動変更:**

- 各コミュニティの `TokenSetting` ストレージに保存されている `maxIncreaseOfTotalSupplyBp` 値は、日次ミント上限の計算で参照されなくなる。従来のローカル値が新しいプロトコル横断値と異なっていたコミュニティは、アップグレード直後から実質日次上限が変化する。
- 「このコミュニティの日次ミント上限」を表示するツールは、per-community 値ではなく `PCEToken.maxIncreaseOfTotalSupplyBp()` を読む必要がある。per-community フィールドの読み出しは引き続き保存値を返すが、その値はミント挙動を駆動しない。

**非破壊的:**

- `createToken` / `setTokenSettings` / `getTokenSettings` のシグネチャ・引数順・戻りタプルはすべて不変。既存スクリプト・フロントエンドは ABI 変更不要。pass-through で値は保存されるがミントロジックには影響しない。
- 送金個別の報酬形状（`maxIncreaseBp` / `maxUsageBp` / `changeBp`）は不変。コミュニティが引き続きローカル設定する。
- 減衰（`afterDecreaseBp` / `decreaseIntervalDays`）、swap（`swapFromLocalToken` / `swapToLocalToken` / `swapTokens`）、`Transfer`、allowance、voucher、EIP-3009 のパスは未変更。
- PCEToken のストレージレイアウトは末尾に 1 スロット追加するのみ。PCECommunityToken のストレージレイアウトは不変。

### Test Cases（テストケース）

以下は `BP_BASE = 10_000` を仮定し、アップグレード直後にガバナンスが `PCEToken.maxIncreaseOfTotalSupplyBp = 100`（= 1%）を設定した状態を例とする。Community Token の量は `midnightTotalSupply` と同じ raw 値（factor 適用前）で記述する。

**Case 1: 同サイズ・同上限比率のコミュニティ 2 つ**
- Community A: `midnightTotalSupply = 10_000 ether`
- Community B: `midnightTotalSupply = 10_000 ether`
- 両コミュニティの旧 per-community `maxIncreaseOfTotalSupplyBp` は異なっていた（A: 100, B: 50）。アップグレード後はどちらも PCEToken の値（= 100）を読む。
- `maxArigatoCreationMintToday(A) = 100 ether` / `maxArigatoCreationMintToday(B) = 100 ether`
- 結果: コミュニティ間で上限完全に同一。旧来異なっていたローカル値はもはや影響を持たない。

**Case 2: 異サイズ・同上限比率のコミュニティ**
- Community A: `midnightTotalSupply = 10_000 ether`（PCE BASE Token 総量 ≈ 10_000 PCE）
- Community B: `midnightTotalSupply = 1_000 ether`（PCE BASE Token 総量 ≈ 1_000 PCE）
- `maxArigatoCreationMintToday(A) = 100 ether（≈ 100 PCE 相当）`
- `maxArigatoCreationMintToday(B) = 10 ether（≈ 10 PCE 相当）`
- 結果: コミュニティごとの裏付け価値に対して同じ比率（1%）。

**Case 3: ガバナンスによる上限変更**
- 初期状態: `PCEToken.maxIncreaseOfTotalSupplyBp = 100`（1%）
- ガバナンスが `setMaxIncreaseOfTotalSupplyBp(50)`（0.5%）を実行
- イベント: `MaxIncreaseOfTotalSupplyBpSet(100, 50)`
- 任意のコミュニティでの次回 ARIGATO CREATION ミントから新しい 0.5% 上限が適用される。
- どの `PCECommunityToken` の状態変更も不要。

**Case 4: 上限 0 によるミント停止**
- `PCEToken.maxIncreaseOfTotalSupplyBp = 0`
- ARIGATO CREATION をトリガーする送金は通常通り transfer として完了するが、追加ミント量は `0`。
- 現状でもコミュニティの per-community `maxIncreaseOfTotalSupplyBp == 0` のときと同じ挙動。

**Case 5: per-community フィールドは設定可能だが無効**
- Community A の所有者が `setTokenSettings(..., maxIncreaseOfTotalSupplyBp = 5_000, ...)`（50%）を呼ぶ。
- 値は Community A のストレージに書き込まれる。`getTokenSettings()` はそれを返す。
- 直後に Community A で送金を行っても、ミントはプロトコル横断上限（PCEToken の値が 100 なら 1%）で計算される。ローカルの 50% は影響しない。

**Case 6: 範囲外入力で revert**
- ガバナンスが `setMaxIncreaseOfTotalSupplyBp(10_001)` を実行。
- `"Bp <= 10000"` で revert MUST。

**Case 7: ガバナンス以外からの設定不可**
- 任意の non-owner アドレスが `setMaxIncreaseOfTotalSupplyBp(50)` を呼ぶ。
- revert MUST（OpenZeppelin `OwnableUnauthorizedAccount` エラー）。

### Security Considerations（セキュリティ考察）

**上限制御の中央集権化**: 本 PIP 後は、全コミュニティの日次ミント上限が単一のガバナンス管理値で決まる。これは設計上の意図 — per-community の自由度を 1 軸取り除くことが本 PIP の目的である。標準的な PCE ガバナンス保護（提案から執行までの Timelock 遅延、Governor のクォーラム・投票期間）が突発的または敵対的な変更を抑制する。実装は Timelock 遅延がコミュニティ側の対応に十分な期間であることを SHOULD 確認する。

**アトミック初期化不変条件**: *Upgrade procedure* で述べた通り、アップグレードと初期 `setMaxIncreaseOfTotalSupplyBp` 呼び出しを別トランザクションに分割すると、その間プロトコル全体でミント停止期間が発生する。ガバナンスは両者を単一提案にバンドル MUST。提案文には初期値を明示的に含め、レビュアーが値を確認できるように SHOULD する。

**読み取りパスの結合**: `PCECommunityToken._mintArigatoCreation` は ARIGATO CREATION をトリガーする全ての送金に対して `PCEToken` への外部 `STATICCALL` を 1 回行うようになる。コールドストレージ読み出し約 1 回分のコストが追加される（メタトランザクションならリレイヤー、直接送金なら送信者が負担）。既存の ERC-20 transfer や ARIGATO CREATION 会計に対して負担は無視できるレベル。

**上限変更のフロントラン**: 上限を引き下げるガバナンス提案を観測した利用者が、変更前により多く旧上限を消費しようとミント対象送金を先回り実行する可能性がある。これはコミュニティ運営者がローカル値を引き下げる場合の現状挙動と形状的に同じで、結局その日の上限自体には縛られる（その日の上限を超えてミントすることはできない）。追加のオンチェーン保護は提案しない。実装は予定変更をオフチェーンで周知 MAY。

**逆方向移行**: 本 PIP は per-community `maxIncreaseOfTotalSupplyBp` に戻すパスを提供しない。将来 per-community 値を再びガバナンスしたくなった場合、別の読み取り切り替えと逆方向のミントパス変更を導入する別 PIP が必要になる。deprecated ストレージスロットを残しているのは、その選択肢を追加のアップグレード安全性リスクなしに開けておくためでもある。

### Notes（補足）

- **影響範囲**: PCEToken（UUPS）と PCECommunityToken（Beacon）の両方にアップグレードが必要。バンドルされた `setMaxIncreaseOfTotalSupplyBp` 呼び出し以外、コミュニティ単位の移行スクリプトは不要。
- **スコープ外**: `maxIncreaseOfTotalSupplyBp` の初期値選定、ガバナンスの見直し頻度。両方とも本 PIP の採択と並行して行うガバナンス判断（後述 *Open governance decisions* 参照）。
- **スコープ外（個人レベルのコミュニティ間中立性）**: 本 PIP は送金個別の報酬率をコミュニティ間で揃えない。`maxIncreaseBp` / `maxUsageBp` / `changeBp` の差により、同じ送金でもコミュニティごとに ARIGATO CREATION 量が異なり続ける。これはコミュニティ内部の分配施策として意図的に残す。
- **スコープ外（PCE BASE Token と `depositedPCEToken` の乖離）**: PCE BASE Token 総量（裏付け価値の概念）と `depositedPCEToken`（実際にロックされている PCE）の構造的乖離は、本 PIP では扱わない別の長期課題である。本 PIP は上限を `midnightTotalSupply`（= PCE BASE Token 対応）に紐付けているため、`depositedPCEToken` の挙動とは独立に中立性が成り立つ。
- **Open governance decisions**（採択と並行して決めるべき判断）:
  1. `maxIncreaseOfTotalSupplyBp` の初期値（既存コミュニティの設定値の調査結果を踏まえる想定）。
  2. 見直しの頻度と、変更判断にあたって参照する指標。
  3. 既存コミュニティ運営者への per-community 設定 deprecation の周知。
- **関連リポジトリ**: [peacecoin-protocol/core](https://github.com/peacecoin-protocol/core) / [peacecoin-protocol/PIPs](https://github.com/peacecoin-protocol/PIPs)。
- **ソース文書**: <https://github.com/nihen/nihen.github.io/blob/main/peacecoin-protocol/arigato-neutrality/README.md>
- **依存関係**: なし。PIP-13 / PIP-15 / PIP-16 / PIP-17 のストレージおよび ABI と互換。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
