### PR TITLE
PIP-19: Proof of Personhood via SBT for Arigato Creation

### DIFF
--- a/PIPs/pip-19.md
+++ b/PIPs/pip-19.md
@@ -19,7 +19,27 @@ This creates a strong incentive to verify (bonus) while removing the incentive t
 
 ## 2. Specification / Details
 
-### 2.1 Privado ID Integration
+### 2.1 Architecture: Responsibility Split Between PCEToken and PCECommunityToken
+
+Identity registration is a **protocol-level** concern — a person's identity is not specific to any single community. Therefore, identity management is placed on `PCEToken` (the parent contract), while per-community daily mint tracking remains on each `PCECommunityToken`.
+
+```
+PCEToken (Parent)
+├─ registerIdentity() / unregisterIdentity()
+├─ walletToIdentity mapping
+├─ isPersonhoodVerified() / getIdentityNullifier()
+├─ personhoodBonusBp (governance parameter)
+└─ PERSONHOOD_REQUEST_ID (governance parameter)
+
+PCECommunityToken (Per-Community Instance)
+├─ identityMintArigatoCreationToday mapping
+├─ identityLastMintResetTime mapping
+└─ Modified _mintArigatoCreation() reads identity from PCEToken
+```
+
+A user registers their identity **once** on `PCEToken`, and all community tokens recognize the verification via `PCEToken.isPersonhoodVerified(wallet)`.
+
+### 2.2 Privado ID Integration
 
 Privado ID (formerly Polygon ID / iden3) provides W3C Verifiable Credentials verified on-chain via zero-knowledge proofs. The protocol uses the **UniversalVerifier** contract to check proof status without exposing personal data.
 
@@ -27,14 +47,14 @@ Privado ID (formerly Polygon ID / iden3) provides W3C Verifiable Credentials ver
 
 A Proof of Personhood credential issued by a trusted Issuer. The specific credential schema and trusted Issuer list are governance-configurable parameters.
 
-#### Identity Registration
+### 2.3 PCEToken: Identity Registration
 
-A new function is added to `PCECommunityToken`:
+New functions are added to `PCEToken`:
+
+#### Registration
 
 ```solidity
-function registerIdentity(
-    uint256 identityNullifier
-) external;
+function registerIdentity(uint256 identityNullifier) external;
 ```
 
 - `identityNullifier` is derived from the user's Privado ID proof. The same identity always produces the same nullifier for a given action, regardless of which wallet submits the proof.
@@ -42,28 +62,57 @@ function registerIdentity(
 - A wallet can only be linked to one identity at a time.
 - Multiple wallets may be linked to the same identity.
 
-#### Storage
+#### Unregistration
+
+```solidity
+function unregisterIdentity() external;
+```
+
+- Removes the wallet-identity link.
+- The wallet reverts to unverified behavior across all community tokens (no bonus, per-wallet cap).
+
+#### Querying
+
+```solidity
+function isPersonhoodVerified(address wallet) external view returns (bool);
+
+function getIdentityNullifier(address wallet) external view returns (uint256);
+```
+
+#### Storage (PCEToken)
 
 ```solidity
 mapping(address => uint256) public walletToIdentity;
 
-mapping(uint256 => uint256) public identityMintArigatoCreationToday;
+address public universalVerifier;
 
-mapping(uint256 => uint256) public identityLastMintResetTime;
-
-uint256 public constant PERSONHOOD_REQUEST_ID = /* governance-set */;
+uint256 public personhoodRequestId;
 
 uint16 public personhoodBonusBp;
 ```
 
-### 2.2 Modified Arigato Creation Algorithm
+### 2.4 PCECommunityToken: Per-Identity Mint Tracking
+
+Each `PCECommunityToken` tracks Arigato Creation minted per identity per day, independently from other community tokens.
+
+#### Storage (PCECommunityToken)
+
+```solidity
+mapping(uint256 => uint256) public identityMintArigatoCreationToday;
+
+mapping(uint256 => uint256) public identityLastMintResetTime;
+```
+
+These mappings are keyed by `identityNullifier` and reset at UTC midnight, following the same daily reset logic as the existing `mintArigatoCreationToday`.
+
+### 2.5 Modified Arigato Creation Algorithm
 
 #### Bonus for Verified Users
 
 Verified users receive a bonus applied to the `increaseBp` calculation:
 
 ```
-// Current (PIP-15):
+// Current:
 increaseBp = maxIncreaseBp - (changeMulBp × messageBp) / BP_BASE
 
 // With Proof of Personhood:
@@ -73,11 +122,11 @@ if (isVerified):
     increaseBp = min(increaseBp, maxIncreaseBp)  // cap at max
 ```
 
-`personhoodBonusBp` is a governance-configurable parameter (e.g., 500 = 5% bonus).
+`personhoodBonusBp` is stored on `PCEToken` and read by each `PCECommunityToken` via `PCEToken(pceAddress).personhoodBonusBp()`. Governance-configurable (e.g., 500 = 5% bonus).
 
 #### Per-Identity Daily Mint Limit
 
-For **verified** accounts, the per-account daily mint cap is replaced by a per-identity cap:
+For **verified** accounts, the per-account daily mint cap is replaced by a per-identity cap within each community token:
 
 ```
 // Current: per-wallet cap
@@ -87,7 +136,7 @@ maxForSender = (maxArigatoCreationMintToday × midnightBalance) / midnightTotalS
 identityMidnightBalance = sum of midnightBalance for all wallets linked to this identity
 maxForIdentity = (maxArigatoCreationMintToday × identityMidnightBalance) / midnightTotalSupply
 
-// Already minted across all wallets of this identity
+// Already minted across all wallets of this identity (within THIS community token)
 actualMintedByIdentity = identityMintArigatoCreationToday[identityNullifier]
 
 remainingForIdentity = max(0, maxForIdentity - actualMintedByIdentity)
@@ -106,37 +155,9 @@ maxGuestPerIdentity = (maxArigatoCreationMintToday × 1) / 100  // 1% of daily
 
 This replaces the per-wallet guest cap for verified guests.
 
-### 2.3 Wallet-Identity Lifecycle
+### 2.6 Events
 
-#### Linking
-
-```solidity
-function registerIdentity(uint256 identityNullifier) external;
-```
-
-- Requires `UniversalVerifier.isRequestProofVerified(msg.sender, PERSONHOOD_REQUEST_ID) == true`
-- Sets `walletToIdentity[msg.sender] = identityNullifier`
-- Emits `IdentityRegistered(address indexed wallet, uint256 indexed identityNullifier)`
-
-#### Unlinking
-
-```solidity
-function unregisterIdentity() external;
-```
-
-- Removes the wallet-identity link
-- The wallet reverts to unverified behavior (no bonus, per-wallet cap)
-- Emits `IdentityUnregistered(address indexed wallet, uint256 indexed identityNullifier)`
-
-#### Querying
-
-```solidity
-function isPersonhoodVerified(address wallet) external view returns (bool);
-
-function getIdentityNullifier(address wallet) external view returns (uint256);
-```
-
-### 2.4 New Events
+#### PCEToken Events
 
 ```solidity
 event IdentityRegistered(
@@ -155,29 +176,82 @@ event PersonhoodBonusBpUpdated(
 );
 ```
 
-### 2.5 Governance Parameters
+### 2.7 Governance Parameters
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `PERSONHOOD_REQUEST_ID` | uint256 | Privado ID verification request ID |
-| `personhoodBonusBp` | uint16 | Bonus basis points for verified users |
-| Trusted Issuer list | — | Managed via Privado ID's UniversalVerifier request configuration |
+| Parameter | Contract | Type | Description |
+|-----------|----------|------|-------------|
+| `personhoodRequestId` | PCEToken | uint256 | Privado ID verification request ID |
+| `personhoodBonusBp` | PCEToken | uint16 | Bonus basis points for verified users |
+| `universalVerifier` | PCEToken | address | Privado ID UniversalVerifier contract address |
+| Trusted Issuer list | — | — | Managed via Privado ID's UniversalVerifier request configuration |
 
-## 3. Impact and Compatibility
+## 3. Application Flow
+
+### 3.1 Initial Verification (One-Time)
+
+```
+User                     App                      Privado ID             PCEToken
+ │                        │                        Wallet/SDK             │
+ │  1. "Verify identity"  │                          │                    │
+ │ ───────────────────────>│                          │                    │
+ │                        │  2. Request ZK Proof      │                    │
+ │                        │ ─────────────────────────>│                    │
+ │                        │                          │                    │
+ │  3. Approve in wallet  │                          │                    │
+ │ ──────────────────────────────────────────────────>│                    │
+ │                        │                          │                    │
+ │                        │  4. Proof generated       │                    │
+ │                        │ <─────────────────────────│                    │
+ │                        │                          │                    │
+ │                        │  5. submitResponse() to UniversalVerifier     │
+ │                        │ ──────────────────────────────────────────────>│
+ │                        │                                               │
+ │                        │  6. registerIdentity(nullifier) on PCEToken   │
+ │                        │ ──────────────────────────────────────────────>│
+ │                        │                                               │
+ │  7. "Verified!"        │               Applies to ALL community tokens │
+ │ <───────────────────────│                                               │
+```
+
+Steps 5 and 6 can be batched into a single transaction via a helper contract or multicall.
+
+### 3.2 Ongoing Transfers
+
+After verification, transfers work as usual. The modified `_mintArigatoCreation` internally:
+
+1. Calls `PCEToken(pceAddress).isPersonhoodVerified(sender)` to check verification status.
+2. If verified, applies `personhoodBonusBp` bonus and enforces per-identity daily cap.
+3. No additional user action required.
+
+### 3.3 Credential Issuance Options
+
+| Option | Description | Trust Level |
+|--------|-------------|-------------|
+| **Third-party Issuer** | Existing KYC/PoP providers on Privado ID marketplace | High (established trust) |
+| **PEACE COIN as Issuer** | Self-hosted Issuer Node. App performs verification (e.g., SMS, face recognition) and issues credential | Medium (self-attested) |
+| **Community-based Issuer** | Community owners vouch for members and issue credentials | Low-Medium (social trust) |
+
+PEACE COIN can start with a third-party Issuer and optionally deploy its own Issuer Node later. The on-chain contracts are agnostic to the credential source — they only check the UniversalVerifier proof status.
+
+## 4. Impact and Compatibility
 
 **Backwards Compatibility:** Fully backwards compatible. Unverified accounts continue to operate exactly as before. The bonus and per-identity cap only apply to accounts that opt in by registering their identity.
 
-**Storage:** New storage mappings for wallet-to-identity and per-identity mint tracking. No changes to existing storage layout.
+**Storage:**
+- PCEToken: New mappings for wallet-to-identity and governance parameters. No changes to existing storage layout (appended to end of storage).
+- PCECommunityToken: New mappings for per-identity daily mint tracking. No changes to existing storage layout.
 
-**Contract Size:** Additional functions and storage increase bytecode. Should be monitored alongside PIP-15 additions.
+**Contract Size:** Additional functions on both contracts increase bytecode. Should be monitored alongside PIP-15 additions.
 
 **Privacy:** No personal information is stored on-chain. Only the `identityNullifier` (a pseudonymous, deterministic identifier derived from the ZKP) is recorded. The nullifier is specific to the PEACE COIN action and cannot be used to track the user across other applications.
 
-**Front-end Impact:** Applications should provide UI for identity verification flow (Privado ID wallet interaction) and display verification status.
+**Cross-Community Behavior:** A user who registers identity on PCEToken is verified across all community tokens. However, each community token tracks daily mint independently — minting in Community A does not consume the quota in Community B.
 
-**Gas Impact:** `registerIdentity` requires one storage write (~20k gas) plus Privado ID proof check (view call, 0 gas). Transfer functions add one `SLOAD` (~2.1k gas) to check verification status.
+**Gas Impact:**
+- `registerIdentity`: One storage write (~20k gas) on PCEToken + Privado ID proof submission (~770k gas on the UniversalVerifier, one-time).
+- Transfer functions: One cross-contract `SLOAD` via `PCEToken.isPersonhoodVerified()` (~2.6k gas including call overhead) per transfer.
 
-## 4. Rationale and Alternatives
+## 5. Rationale and Alternatives
 
 **Why Privado ID?**
 - Zero-knowledge proof based: personal data never touches the chain
@@ -199,6 +273,9 @@ event PersonhoodBonusBpUpdated(
 - Auditing and security burden falls entirely on PEACE COIN
 - No ecosystem of credential issuers to leverage
 
+**Why register on PCEToken rather than each PCECommunityToken?**
+Identity is a property of a person, not of a community. Requiring registration per community token would create unnecessary friction (N transactions for N communities) and duplicate storage. Centralizing identity on PCEToken allows one registration to apply protocol-wide, while each community token independently enforces its own daily mint limits.
+
 **Why allow multiple wallets per identity?**
 Users have legitimate reasons to use multiple wallets (operational security, role separation, privacy). Prohibiting this would harm user experience without improving Sybil resistance. Instead, the per-identity cap removes the economic incentive to split across wallets while preserving user freedom.
 
@@ -213,6 +290,6 @@ Making verification mandatory would exclude users in regions where Privado ID is
 - The `identityNullifier` is derived from the user's Privado ID identity commitment and the PEACE COIN-specific action identifier. It is deterministic: the same identity always produces the same nullifier for PEACE COIN, but a different nullifier for other applications.
 - The credential schema for Proof of Personhood and the trusted Issuer list should be determined through governance before implementation.
 
-## 5. Copyright and License
+## 6. Copyright and License
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/PIPs/pip-19.md
+++ b/PIPs/pip-19.md
@@ -1,0 +1,218 @@
+---
+pip: 19
+title: "Proof of Personhood via Privado ID for Arigato Creation"
+proposer: "CHIBA Masahiro (@nihen)"
+status: "Draft"
+type: "Core"
+created: "2026-05-22"
+requires: []
+replaces: []
+---
+
+## 1. Motivation
+
+The current Arigato Creation algorithm applies per-account daily mint limits based on wallet addresses. This design is vulnerable to Sybil attacks — a single person can create multiple wallets to multiply their Arigato Creation rewards, undermining the fair distribution of minted tokens.
+
+To address this, we introduce a Proof of Personhood mechanism using Privado ID. Users who verify their personhood receive a bonus in the Arigato Creation calculation. However, the daily mint limit is enforced **per identity**, not per wallet address. A single identity may operate multiple wallets, but the total Arigato Creation minted across all wallets sharing the same identity is capped as if they were one account.
+
+This creates a strong incentive to verify (bonus) while removing the incentive to create multiple wallets (shared cap).
+
+## 2. Specification / Details
+
+### 2.1 Privado ID Integration
+
+Privado ID (formerly Polygon ID / iden3) provides W3C Verifiable Credentials verified on-chain via zero-knowledge proofs. The protocol uses the **UniversalVerifier** contract to check proof status without exposing personal data.
+
+#### Credential Requirement
+
+A Proof of Personhood credential issued by a trusted Issuer. The specific credential schema and trusted Issuer list are governance-configurable parameters.
+
+#### Identity Registration
+
+A new function is added to `PCECommunityToken`:
+
+```solidity
+function registerIdentity(
+    uint256 identityNullifier
+) external;
+```
+
+- `identityNullifier` is derived from the user's Privado ID proof. The same identity always produces the same nullifier for a given action, regardless of which wallet submits the proof.
+- Before registration, the contract verifies the proof via `UniversalVerifier.isRequestProofVerified(msg.sender, PERSONHOOD_REQUEST_ID)`.
+- A wallet can only be linked to one identity at a time.
+- Multiple wallets may be linked to the same identity.
+
+#### Storage
+
+```solidity
+mapping(address => uint256) public walletToIdentity;
+
+mapping(uint256 => uint256) public identityMintArigatoCreationToday;
+
+mapping(uint256 => uint256) public identityLastMintResetTime;
+
+uint256 public constant PERSONHOOD_REQUEST_ID = /* governance-set */;
+
+uint16 public personhoodBonusBp;
+```
+
+### 2.2 Modified Arigato Creation Algorithm
+
+#### Bonus for Verified Users
+
+Verified users receive a bonus applied to the `increaseBp` calculation:
+
+```
+// Current (PIP-15):
+increaseBp = maxIncreaseBp - (changeMulBp × messageBp) / BP_BASE
+
+// With Proof of Personhood:
+increaseBp = maxIncreaseBp - (changeMulBp × messageBp) / BP_BASE
+if (isVerified):
+    increaseBp = increaseBp + personhoodBonusBp
+    increaseBp = min(increaseBp, maxIncreaseBp)  // cap at max
+```
+
+`personhoodBonusBp` is a governance-configurable parameter (e.g., 500 = 5% bonus).
+
+#### Per-Identity Daily Mint Limit
+
+For **verified** accounts, the per-account daily mint cap is replaced by a per-identity cap:
+
+```
+// Current: per-wallet cap
+maxForSender = (maxArigatoCreationMintToday × midnightBalance) / midnightTotalSupply
+
+// With identity: per-identity cap (sum of all wallets' midnight balances)
+identityMidnightBalance = sum of midnightBalance for all wallets linked to this identity
+maxForIdentity = (maxArigatoCreationMintToday × identityMidnightBalance) / midnightTotalSupply
+
+// Already minted across all wallets of this identity
+actualMintedByIdentity = identityMintArigatoCreationToday[identityNullifier]
+
+remainingForIdentity = max(0, maxForIdentity - actualMintedByIdentity)
+mintAmount = min(mintAmount, remainingForIdentity)
+```
+
+For **unverified** accounts, the existing per-wallet logic remains unchanged.
+
+#### Guest Account Handling
+
+Guest accounts that are verified share the per-identity guest cap:
+
+```
+maxGuestPerIdentity = (maxArigatoCreationMintToday × 1) / 100  // 1% of daily
+```
+
+This replaces the per-wallet guest cap for verified guests.
+
+### 2.3 Wallet-Identity Lifecycle
+
+#### Linking
+
+```solidity
+function registerIdentity(uint256 identityNullifier) external;
+```
+
+- Requires `UniversalVerifier.isRequestProofVerified(msg.sender, PERSONHOOD_REQUEST_ID) == true`
+- Sets `walletToIdentity[msg.sender] = identityNullifier`
+- Emits `IdentityRegistered(address indexed wallet, uint256 indexed identityNullifier)`
+
+#### Unlinking
+
+```solidity
+function unregisterIdentity() external;
+```
+
+- Removes the wallet-identity link
+- The wallet reverts to unverified behavior (no bonus, per-wallet cap)
+- Emits `IdentityUnregistered(address indexed wallet, uint256 indexed identityNullifier)`
+
+#### Querying
+
+```solidity
+function isPersonhoodVerified(address wallet) external view returns (bool);
+
+function getIdentityNullifier(address wallet) external view returns (uint256);
+```
+
+### 2.4 New Events
+
+```solidity
+event IdentityRegistered(
+    address indexed wallet,
+    uint256 indexed identityNullifier
+);
+
+event IdentityUnregistered(
+    address indexed wallet,
+    uint256 indexed identityNullifier
+);
+
+event PersonhoodBonusBpUpdated(
+    uint16 oldBonusBp,
+    uint16 newBonusBp
+);
+```
+
+### 2.5 Governance Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `PERSONHOOD_REQUEST_ID` | uint256 | Privado ID verification request ID |
+| `personhoodBonusBp` | uint16 | Bonus basis points for verified users |
+| Trusted Issuer list | — | Managed via Privado ID's UniversalVerifier request configuration |
+
+## 3. Impact and Compatibility
+
+**Backwards Compatibility:** Fully backwards compatible. Unverified accounts continue to operate exactly as before. The bonus and per-identity cap only apply to accounts that opt in by registering their identity.
+
+**Storage:** New storage mappings for wallet-to-identity and per-identity mint tracking. No changes to existing storage layout.
+
+**Contract Size:** Additional functions and storage increase bytecode. Should be monitored alongside PIP-15 additions.
+
+**Privacy:** No personal information is stored on-chain. Only the `identityNullifier` (a pseudonymous, deterministic identifier derived from the ZKP) is recorded. The nullifier is specific to the PEACE COIN action and cannot be used to track the user across other applications.
+
+**Front-end Impact:** Applications should provide UI for identity verification flow (Privado ID wallet interaction) and display verification status.
+
+**Gas Impact:** `registerIdentity` requires one storage write (~20k gas) plus Privado ID proof check (view call, 0 gas). Transfer functions add one `SLOAD` (~2.1k gas) to check verification status.
+
+## 4. Rationale and Alternatives
+
+**Why Privado ID?**
+- Zero-knowledge proof based: personal data never touches the chain
+- UniversalVerifier provides a simple `isRequestProofVerified()` view function — minimal integration complexity
+- Supports arbitrary credential schemas: can start with Proof of Personhood and extend to other credential types later
+- Protocol fees: free (open source). Only gas costs
+- PEACE COIN can become its own Issuer if needed
+- Lower regulatory risk compared to biometric-dependent alternatives (e.g., World ID's iris scanning has been banned in multiple countries)
+
+**Why not World ID?**
+- Requires physical Orb visit for verification
+- Primarily Proof of Personhood only (no extensibility to other credential types)
+- Regulatory risk: banned or suspended in Brazil, Philippines, Thailand, Indonesia
+- Protocol in transition (v3 → v4) with breaking changes
+- Application developer fees being introduced (amounts undisclosed)
+
+**Why not a custom implementation?**
+- ZKP circuits require specialized cryptographic expertise
+- Auditing and security burden falls entirely on PEACE COIN
+- No ecosystem of credential issuers to leverage
+
+**Why allow multiple wallets per identity?**
+Users have legitimate reasons to use multiple wallets (operational security, role separation, privacy). Prohibiting this would harm user experience without improving Sybil resistance. Instead, the per-identity cap removes the economic incentive to split across wallets while preserving user freedom.
+
+**Why a bonus rather than a requirement?**
+Making verification mandatory would exclude users in regions where Privado ID issuers are unavailable. A bonus-based approach creates a gradual incentive to verify without hard-gating participation.
+
+## Notes (Optional)
+
+- Related implementation: https://github.com/peacecoin-protocol/core/pull/TBD
+- Privado ID UniversalVerifier: `0xfcc86A79fCb057A8e55C6B853dff9479C3cf607c` (all EVM chains)
+- Privado ID documentation: https://docs.privado.id/
+- The `identityNullifier` is derived from the user's Privado ID identity commitment and the PEACE COIN-specific action identifier. It is deterministic: the same identity always produces the same nullifier for PEACE COIN, but a different nullifier for other applications.
+- The credential schema for Proof of Personhood and the trusted Issuer list should be determined through governance before implementation.
+
+## 5. Copyright and License
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/PIPs/pip-19.md
+++ b/PIPs/pip-19.md
@@ -1,6 +1,6 @@
 ---
 pip: 19
-title: "Proof of Personhood via Privado ID for Arigato Creation"
+title: "Proof of Personhood via SBT for Arigato Creation"
 proposer: "CHIBA Masahiro (@nihen)"
 status: "Draft"
 type: "Core"
@@ -13,89 +13,141 @@ replaces: []
 
 The current Arigato Creation algorithm applies per-account daily mint limits based on wallet addresses. This design is vulnerable to Sybil attacks — a single person can create multiple wallets to multiply their Arigato Creation rewards, undermining the fair distribution of minted tokens.
 
-To address this, we introduce a Proof of Personhood mechanism using Privado ID. Users who verify their personhood receive a bonus in the Arigato Creation calculation. However, the daily mint limit is enforced **per identity**, not per wallet address. A single identity may operate multiple wallets, but the total Arigato Creation minted across all wallets sharing the same identity is capped as if they were one account.
+To address this, we introduce a Proof of Personhood mechanism using a Soulbound Token (SBT). Users who hold a personhood SBT receive a bonus in the Arigato Creation calculation. However, the daily mint limit is enforced **per identity**, not per wallet address. A single identity may operate multiple wallets (each holding an SBT with the same `identityId`), but the total Arigato Creation minted across all wallets sharing the same identity is capped as if they were one account.
 
-This creates a strong incentive to verify (bonus) while removing the incentive to create multiple wallets (shared cap).
+By using an SBT as the interface, the core protocol is completely agnostic to the identity verification method. The SBT minting process can use Privado ID, World ID, or any other verification mechanism — and can be swapped without modifying PCEToken or PCECommunityToken.
 
 ## 2. Specification / Details
 
-### 2.1 Architecture: Responsibility Split Between PCEToken and PCECommunityToken
-
-Identity registration is a **protocol-level** concern — a person's identity is not specific to any single community. Therefore, identity management is placed on `PCEToken` (the parent contract), while per-community daily mint tracking remains on each `PCECommunityToken`.
+### 2.1 Architecture Overview
 
 ```
-PCEToken (Parent)
-├─ registerIdentity() / unregisterIdentity()
-├─ walletToIdentity mapping
-├─ isPersonhoodVerified() / getIdentityNullifier()
-├─ personhoodBonusBp (governance parameter)
-└─ PERSONHOOD_REQUEST_ID (governance parameter)
-
-PCECommunityToken (Per-Community Instance)
-├─ identityMintArigatoCreationToday mapping
-├─ identityLastMintResetTime mapping
-└─ Modified _mintArigatoCreation() reads identity from PCEToken
+┌─────────────────────────────────────────────────────┐
+│  Verification Layer (swappable)                     │
+│  ┌─────────────┐ ┌─────────────┐ ┌───────────────┐ │
+│  │ Privado ID  │ │  World ID   │ │ Custom Verify │ │
+│  └──────┬──────┘ └──────┬──────┘ └───────┬───────┘ │
+│         └───────────┬───┘               │         │
+│                     ▼                   ▼         │
+│              ┌──────────────┐                     │
+│              │ Minter (Auth)│ ◄───────────────────┘ │
+│              └──────┬───────┘                       │
+└─────────────────────┼───────────────────────────────┘
+                      ▼
+               ┌──────────────┐
+               │  SBT Contract │  ERC-5192 (Soulbound)
+               │  (PCE PoP)   │  identityId per wallet
+               └──────┬───────┘
+                      │ balanceOf / identityOf
+         ┌────────────┴────────────┐
+         ▼                         ▼
+  ┌────────────┐          ┌──────────────────────┐
+  │  PCEToken  │          │ PCECommunityToken (×N)│
+  │  (Parent)  │          │ Per-community mint    │
+  │            │          │ tracking per identity │
+  └────────────┘          └──────────────────────┘
 ```
 
-A user registers their identity **once** on `PCEToken`, and all community tokens recognize the verification via `PCEToken.isPersonhoodVerified(wallet)`.
+The core protocol (PCEToken + PCECommunityToken) only depends on the SBT contract interface. The verification method is an implementation detail of the Minter, which can be upgraded or replaced independently.
 
-### 2.2 Privado ID Integration
+### 2.2 SBT Contract (PCE Proof of Personhood Token)
 
-Privado ID (formerly Polygon ID / iden3) provides W3C Verifiable Credentials verified on-chain via zero-knowledge proofs. The protocol uses the **UniversalVerifier** contract to check proof status without exposing personal data.
+A new Soulbound Token contract compliant with [ERC-5192](https://eips.ethereum.org/EIPS/eip-5192) (Minimal Soulbound NFTs).
 
-#### Credential Requirement
-
-A Proof of Personhood credential issued by a trusted Issuer. The specific credential schema and trusted Issuer list are governance-configurable parameters.
-
-### 2.3 PCEToken: Identity Registration
-
-New functions are added to `PCEToken`:
-
-#### Registration
+#### Interface
 
 ```solidity
-function registerIdentity(uint256 identityNullifier) external;
+interface IPCEPersonhood {
+    /// @notice Returns the identity ID for a wallet. Reverts if wallet has no SBT.
+    function identityOf(address wallet) external view returns (uint256);
+
+    /// @notice Returns true if the wallet holds a personhood SBT.
+    function hasPersonhood(address wallet) external view returns (bool);
+
+    /// @notice Mint a personhood SBT to a wallet. Only callable by authorized minters.
+    /// @param wallet The wallet to receive the SBT.
+    /// @param identityId The identity group. Same person's wallets share the same identityId.
+    function mint(address wallet, uint256 identityId) external;
+
+    /// @notice Burn the SBT from a wallet. Callable by the wallet owner or authorized minters.
+    function burn(address wallet) external;
+
+    /// @notice ERC-5192: All tokens are locked (soulbound).
+    function locked(uint256 tokenId) external view returns (bool);
+
+    event Mint(address indexed wallet, uint256 indexed identityId, uint256 tokenId);
+    event Burn(address indexed wallet, uint256 indexed identityId, uint256 tokenId);
+}
 ```
 
-- `identityNullifier` is derived from the user's Privado ID proof. The same identity always produces the same nullifier for a given action, regardless of which wallet submits the proof.
-- Before registration, the contract verifies the proof via `UniversalVerifier.isRequestProofVerified(msg.sender, PERSONHOOD_REQUEST_ID)`.
-- A wallet can only be linked to one identity at a time.
-- Multiple wallets may be linked to the same identity.
+#### Properties
 
-#### Unregistration
+- **Non-transferable**: `transfer` and `transferFrom` always revert. Compliant with ERC-5192.
+- **One SBT per wallet**: A wallet can hold at most one personhood SBT.
+- **Shared identityId**: Multiple wallets belonging to the same person are minted with the same `identityId`.
+- **Authorized minters**: Only addresses with the `MINTER_ROLE` can call `mint`. The minter role is managed via access control (e.g., OpenZeppelin `AccessControl`).
+- **Burnable**: The wallet owner can burn their own SBT to opt out. Authorized minters can also burn (e.g., for revocation).
+
+### 2.3 Minter Contract (Verification Layer)
+
+The Minter contract is responsible for verifying identity and calling `SBT.mint()`. This is the only component that depends on a specific verification provider.
+
+#### Example: Privado ID Minter
 
 ```solidity
-function unregisterIdentity() external;
+contract PrivadoIDMinter {
+    IPCEPersonhood public sbt;
+    IUniversalVerifier public universalVerifier;
+    uint256 public requestId;
+
+    function verifyAndMint(uint256 identityId) external {
+        require(
+            universalVerifier.isRequestProofVerified(msg.sender, requestId),
+            "Proof not verified"
+        );
+        sbt.mint(msg.sender, identityId);
+    }
+}
 ```
 
-- Removes the wallet-identity link.
-- The wallet reverts to unverified behavior across all community tokens (no bonus, per-wallet cap).
+Other minter implementations can use World ID, custom SMS/face verification, community vouching, or any other mechanism. Multiple minters can coexist — the SBT contract only checks `MINTER_ROLE`.
 
-#### Querying
+### 2.4 PCEToken: Identity Querying
 
-```solidity
-function isPersonhoodVerified(address wallet) external view returns (bool);
+`PCEToken` stores the SBT contract address and provides convenience functions read by all community tokens.
 
-function getIdentityNullifier(address wallet) external view returns (uint256);
-```
-
-#### Storage (PCEToken)
+#### New Storage
 
 ```solidity
-mapping(address => uint256) public walletToIdentity;
-
-address public universalVerifier;
-
-uint256 public personhoodRequestId;
+address public personhoodSBT;
 
 uint16 public personhoodBonusBp;
 ```
 
-### 2.4 PCECommunityToken: Per-Identity Mint Tracking
+#### New Functions
+
+```solidity
+function setPersonhoodSBT(address sbt) external onlyOwner;
+
+function setPersonhoodBonusBp(uint16 bonusBp) external onlyOwner;
+
+function isPersonhoodVerified(address wallet) external view returns (bool) {
+    if (personhoodSBT == address(0)) return false;
+    return IPCEPersonhood(personhoodSBT).hasPersonhood(wallet);
+}
+
+function getIdentityId(address wallet) external view returns (uint256) {
+    return IPCEPersonhood(personhoodSBT).identityOf(wallet);
+}
+```
+
+No `registerIdentity` / `unregisterIdentity` is needed on PCEToken — the SBT itself is the registration.
+
+### 2.5 PCECommunityToken: Per-Identity Mint Tracking
 
 Each `PCECommunityToken` tracks Arigato Creation minted per identity per day, independently from other community tokens.
 
-#### Storage (PCECommunityToken)
+#### New Storage
 
 ```solidity
 mapping(uint256 => uint256) public identityMintArigatoCreationToday;
@@ -103,13 +155,13 @@ mapping(uint256 => uint256) public identityMintArigatoCreationToday;
 mapping(uint256 => uint256) public identityLastMintResetTime;
 ```
 
-These mappings are keyed by `identityNullifier` and reset at UTC midnight, following the same daily reset logic as the existing `mintArigatoCreationToday`.
+These mappings are keyed by `identityId` (from the SBT) and reset at UTC midnight, following the same daily reset logic as the existing `mintArigatoCreationToday`.
 
-### 2.5 Modified Arigato Creation Algorithm
+### 2.6 Modified Arigato Creation Algorithm
 
 #### Bonus for Verified Users
 
-Verified users receive a bonus applied to the `increaseBp` calculation:
+Verified users (SBT holders) receive a bonus applied to the `increaseBp` calculation:
 
 ```
 // Current:
@@ -117,7 +169,7 @@ increaseBp = maxIncreaseBp - (changeMulBp × messageBp) / BP_BASE
 
 // With Proof of Personhood:
 increaseBp = maxIncreaseBp - (changeMulBp × messageBp) / BP_BASE
-if (isVerified):
+if (PCEToken.isPersonhoodVerified(sender)):
     increaseBp = increaseBp + personhoodBonusBp
     increaseBp = min(increaseBp, maxIncreaseBp)  // cap at max
 ```
@@ -129,45 +181,37 @@ if (isVerified):
 For **verified** accounts, the per-account daily mint cap is replaced by a per-identity cap within each community token:
 
 ```
-// Current: per-wallet cap
-maxForSender = (maxArigatoCreationMintToday × midnightBalance) / midnightTotalSupply
+identityId = PCEToken.getIdentityId(sender)
 
-// With identity: per-identity cap (sum of all wallets' midnight balances)
-identityMidnightBalance = sum of midnightBalance for all wallets linked to this identity
+// Per-identity cap (sum of all wallets' midnight balances)
+identityMidnightBalance = sum of midnightBalance for all wallets with this identityId
 maxForIdentity = (maxArigatoCreationMintToday × identityMidnightBalance) / midnightTotalSupply
 
 // Already minted across all wallets of this identity (within THIS community token)
-actualMintedByIdentity = identityMintArigatoCreationToday[identityNullifier]
+actualMintedByIdentity = identityMintArigatoCreationToday[identityId]
 
 remainingForIdentity = max(0, maxForIdentity - actualMintedByIdentity)
 mintAmount = min(mintAmount, remainingForIdentity)
 ```
 
-For **unverified** accounts, the existing per-wallet logic remains unchanged.
+For **unverified** accounts (no SBT), the existing per-wallet logic remains unchanged.
 
 #### Guest Account Handling
 
-Guest accounts that are verified share the per-identity guest cap:
+Guest accounts that hold an SBT share the per-identity guest cap:
 
 ```
 maxGuestPerIdentity = (maxArigatoCreationMintToday × 1) / 100  // 1% of daily
 ```
 
-This replaces the per-wallet guest cap for verified guests.
-
-### 2.6 Events
+### 2.7 Events
 
 #### PCEToken Events
 
 ```solidity
-event IdentityRegistered(
-    address indexed wallet,
-    uint256 indexed identityNullifier
-);
-
-event IdentityUnregistered(
-    address indexed wallet,
-    uint256 indexed identityNullifier
+event PersonhoodSBTUpdated(
+    address indexed oldSBT,
+    address indexed newSBT
 );
 
 event PersonhoodBonusBpUpdated(
@@ -176,119 +220,131 @@ event PersonhoodBonusBpUpdated(
 );
 ```
 
-### 2.7 Governance Parameters
+SBT mint/burn events are emitted by the SBT contract itself.
+
+### 2.8 Governance Parameters
 
 | Parameter | Contract | Type | Description |
 |-----------|----------|------|-------------|
-| `personhoodRequestId` | PCEToken | uint256 | Privado ID verification request ID |
-| `personhoodBonusBp` | PCEToken | uint16 | Bonus basis points for verified users |
-| `universalVerifier` | PCEToken | address | Privado ID UniversalVerifier contract address |
-| Trusted Issuer list | — | — | Managed via Privado ID's UniversalVerifier request configuration |
+| `personhoodSBT` | PCEToken | address | SBT contract address |
+| `personhoodBonusBp` | PCEToken | uint16 | Bonus basis points for SBT holders |
+| Minter roles | SBT | — | Managed via SBT contract's access control |
 
 ## 3. Application Flow
 
 ### 3.1 Initial Verification (One-Time)
 
 ```
-User                     App                      Privado ID             PCEToken
- │                        │                        Wallet/SDK             │
- │  1. "Verify identity"  │                          │                    │
- │ ───────────────────────>│                          │                    │
- │                        │  2. Request ZK Proof      │                    │
- │                        │ ─────────────────────────>│                    │
- │                        │                          │                    │
- │  3. Approve in wallet  │                          │                    │
- │ ──────────────────────────────────────────────────>│                    │
- │                        │                          │                    │
- │                        │  4. Proof generated       │                    │
- │                        │ <─────────────────────────│                    │
- │                        │                          │                    │
- │                        │  5. submitResponse() to UniversalVerifier     │
- │                        │ ──────────────────────────────────────────────>│
- │                        │                                               │
- │                        │  6. registerIdentity(nullifier) on PCEToken   │
- │                        │ ──────────────────────────────────────────────>│
- │                        │                                               │
- │  7. "Verified!"        │               Applies to ALL community tokens │
- │ <───────────────────────│                                               │
+User                App                  Minter            SBT Contract
+ │                   │                    │                  │
+ │  1. "Verify"      │                    │                  │
+ │ ─────────────────>│                    │                  │
+ │                   │                    │                  │
+ │                   │  2. Trigger verification (e.g., Privado ID proof)
+ │                   │ ──────────────────>│                  │
+ │                   │                    │                  │
+ │  3. Complete      │                    │                  │
+ │  verification     │                    │                  │
+ │ ─────────────────────────────────────>│                  │
+ │                   │                    │                  │
+ │                   │                    │ 4. mint(wallet,  │
+ │                   │                    │    identityId)   │
+ │                   │                    │ ────────────────>│
+ │                   │                    │                  │
+ │  5. "Verified! SBT received"          │                  │
+ │ <─────────────────│                    │                  │
+ │                   │                    │                  │
+ │         Applies to ALL community tokens instantly        │
 ```
 
-Steps 5 and 6 can be batched into a single transaction via a helper contract or multicall.
+### 3.2 Adding Another Wallet
 
-### 3.2 Ongoing Transfers
+```
+User                App                  Minter            SBT Contract
+ │                   │                    │                  │
+ │  1. "Add wallet"  │                    │                  │
+ │  (from new wallet)│                    │                  │
+ │ ─────────────────>│                    │                  │
+ │                   │  2. Verify same person (link to existing identityId)
+ │                   │ ──────────────────>│                  │
+ │                   │                    │ 3. mint(newWallet,│
+ │                   │                    │    sameIdentityId)│
+ │                   │                    │ ────────────────>│
+ │                   │                    │                  │
+ │  4. "New wallet linked"               │                  │
+ │ <─────────────────│                    │                  │
+```
 
-After verification, transfers work as usual. The modified `_mintArigatoCreation` internally:
+### 3.3 Ongoing Transfers
 
-1. Calls `PCEToken(pceAddress).isPersonhoodVerified(sender)` to check verification status.
+After SBT issuance, transfers work as usual. The modified `_mintArigatoCreation` internally:
+
+1. Calls `PCEToken(pceAddress).isPersonhoodVerified(sender)` — checks SBT ownership.
 2. If verified, applies `personhoodBonusBp` bonus and enforces per-identity daily cap.
 3. No additional user action required.
 
-### 3.3 Credential Issuance Options
+### 3.4 Minter Implementation Options
 
-| Option | Description | Trust Level |
-|--------|-------------|-------------|
-| **Third-party Issuer** | Existing KYC/PoP providers on Privado ID marketplace | High (established trust) |
-| **PEACE COIN as Issuer** | Self-hosted Issuer Node. App performs verification (e.g., SMS, face recognition) and issues credential | Medium (self-attested) |
-| **Community-based Issuer** | Community owners vouch for members and issue credentials | Low-Medium (social trust) |
+| Minter Type | Verification Method | Trust Level | Deployment |
+|-------------|---------------------|-------------|------------|
+| **Privado ID Minter** | ZKP via UniversalVerifier | High | Recommended initial |
+| **World ID Minter** | Orb-based iris scan | High | Regional limitations |
+| **SMS Minter** | Phone number verification | Medium | Easy onboarding |
+| **Community Minter** | Community owner vouching | Low-Medium | Social trust |
 
-PEACE COIN can start with a third-party Issuer and optionally deploy its own Issuer Node later. The on-chain contracts are agnostic to the credential source — they only check the UniversalVerifier proof status.
+Multiple minters can be authorized simultaneously on the SBT contract. New minters can be added or revoked without changing PCEToken or PCECommunityToken.
 
 ## 4. Impact and Compatibility
 
-**Backwards Compatibility:** Fully backwards compatible. Unverified accounts continue to operate exactly as before. The bonus and per-identity cap only apply to accounts that opt in by registering their identity.
+**Backwards Compatibility:** Fully backwards compatible. Unverified accounts (no SBT) continue to operate exactly as before. The bonus and per-identity cap only apply to SBT holders.
 
 **Storage:**
-- PCEToken: New mappings for wallet-to-identity and governance parameters. No changes to existing storage layout (appended to end of storage).
-- PCECommunityToken: New mappings for per-identity daily mint tracking. No changes to existing storage layout.
+- PCEToken: `personhoodSBT` address and `personhoodBonusBp`. Appended to end of storage.
+- PCECommunityToken: Per-identity daily mint tracking mappings. Appended to end of storage.
+- No changes to existing storage layout in either contract.
 
-**Contract Size:** Additional functions on both contracts increase bytecode. Should be monitored alongside PIP-15 additions.
+**New Contract:** One new SBT contract (ERC-5192) + one or more Minter contracts. These are independent deployments, not modifications to existing contracts.
 
-**Privacy:** No personal information is stored on-chain. Only the `identityNullifier` (a pseudonymous, deterministic identifier derived from the ZKP) is recorded. The nullifier is specific to the PEACE COIN action and cannot be used to track the user across other applications.
+**Contract Size:** Minimal additions to PCEToken (two storage vars, two setters, two view functions) and PCECommunityToken (modified `_mintArigatoCreation`). Much smaller footprint than embedding verification logic directly.
 
-**Cross-Community Behavior:** A user who registers identity on PCEToken is verified across all community tokens. However, each community token tracks daily mint independently — minting in Community A does not consume the quota in Community B.
+**Privacy:** The SBT contract stores `wallet → identityId` mapping. `identityId` is a pseudonymous identifier — it reveals that two wallets belong to the same person, but nothing about who that person is. No personal information is stored on-chain.
+
+**Cross-Community Behavior:** SBT ownership is protocol-wide (checked via PCEToken). Each community token tracks daily mint independently — minting in Community A does not consume the quota in Community B.
 
 **Gas Impact:**
-- `registerIdentity`: One storage write (~20k gas) on PCEToken + Privado ID proof submission (~770k gas on the UniversalVerifier, one-time).
-- Transfer functions: One cross-contract `SLOAD` via `PCEToken.isPersonhoodVerified()` (~2.6k gas including call overhead) per transfer.
+- SBT mint: ~50k gas (one-time).
+- Transfer functions: One cross-contract call to `PCEToken.isPersonhoodVerified()` which calls `SBT.hasPersonhood()` (~5k gas total including call overhead).
+
+**Upgradeability:**
+- Verification method can be changed by deploying a new Minter and granting it `MINTER_ROLE` on the SBT contract. No PCEToken or PCECommunityToken upgrade needed.
+- SBT contract itself can be replaced by calling `PCEToken.setPersonhoodSBT(newAddress)`.
 
 ## 5. Rationale and Alternatives
 
-**Why Privado ID?**
-- Zero-knowledge proof based: personal data never touches the chain
-- UniversalVerifier provides a simple `isRequestProofVerified()` view function — minimal integration complexity
-- Supports arbitrary credential schemas: can start with Proof of Personhood and extend to other credential types later
-- Protocol fees: free (open source). Only gas costs
-- PEACE COIN can become its own Issuer if needed
-- Lower regulatory risk compared to biometric-dependent alternatives (e.g., World ID's iris scanning has been banned in multiple countries)
+**Why SBT as the interface?**
+Using an SBT decouples identity verification from the core protocol. PCEToken and PCECommunityToken only ask "does this wallet hold a personhood SBT?" — they never need to know how verification was performed. This allows the verification method to evolve independently. Adding a new provider means deploying a new Minter contract, not upgrading the token contracts.
 
-**Why not World ID?**
-- Requires physical Orb visit for verification
-- Primarily Proof of Personhood only (no extensibility to other credential types)
-- Regulatory risk: banned or suspended in Brazil, Philippines, Thailand, Indonesia
-- Protocol in transition (v3 → v4) with breaking changes
-- Application developer fees being introduced (amounts undisclosed)
+**Why ERC-5192?**
+ERC-5192 is the minimal soulbound standard. It extends ERC-721 with a `locked()` function that always returns `true`, signaling non-transferability. Wallets and marketplaces that support ERC-5192 will correctly display the token as non-transferable.
 
-**Why not a custom implementation?**
-- ZKP circuits require specialized cryptographic expertise
-- Auditing and security burden falls entirely on PEACE COIN
-- No ecosystem of credential issuers to leverage
+**Why not embed Privado ID / World ID directly in PCEToken?**
+Direct embedding creates a hard dependency on a specific provider. If that provider changes its API (as World ID did from v3 → v4), the token contracts must be upgraded. With the SBT pattern, only the Minter contract changes.
 
-**Why register on PCEToken rather than each PCECommunityToken?**
-Identity is a property of a person, not of a community. Requiring registration per community token would create unnecessary friction (N transactions for N communities) and duplicate storage. Centralizing identity on PCEToken allows one registration to apply protocol-wide, while each community token independently enforces its own daily mint limits.
+**Why allow multiple minters?**
+Different regions and user segments may prefer different verification methods. A user in Japan might use World ID (Orbs available), while a user elsewhere might use Privado ID or SMS verification. Multiple minters allow maximum reach without forcing a single method.
 
 **Why allow multiple wallets per identity?**
 Users have legitimate reasons to use multiple wallets (operational security, role separation, privacy). Prohibiting this would harm user experience without improving Sybil resistance. Instead, the per-identity cap removes the economic incentive to split across wallets while preserving user freedom.
 
 **Why a bonus rather than a requirement?**
-Making verification mandatory would exclude users in regions where Privado ID issuers are unavailable. A bonus-based approach creates a gradual incentive to verify without hard-gating participation.
+Making verification mandatory would exclude users who cannot or choose not to verify. A bonus-based approach creates a gradual incentive to verify without hard-gating participation.
 
 ## Notes (Optional)
 
 - Related implementation: https://github.com/peacecoin-protocol/core/pull/TBD
-- Privado ID UniversalVerifier: `0xfcc86A79fCb057A8e55C6B853dff9479C3cf607c` (all EVM chains)
-- Privado ID documentation: https://docs.privado.id/
-- The `identityNullifier` is derived from the user's Privado ID identity commitment and the PEACE COIN-specific action identifier. It is deterministic: the same identity always produces the same nullifier for PEACE COIN, but a different nullifier for other applications.
-- The credential schema for Proof of Personhood and the trusted Issuer list should be determined through governance before implementation.
+- Recommended initial Minter: Privado ID (`UniversalVerifier: 0xfcc86A79fCb057A8e55C6B853dff9479C3cf607c`)
+- The `identityId` generation strategy is a Minter implementation detail. For Privado ID, it can be derived from the ZKP nullifier. For other providers, it can be any deterministic identifier that uniquely represents a person.
+- The credential schema for Proof of Personhood and the trusted Issuer list are Minter-level configurations, not protocol-level parameters.
 
 ## 6. Copyright and License
 


### PR DESCRIPTION
## Summary

- Add PIP-19: Proof of Personhood via SBT for Arigato Creation
- **PIP full text**: [PIPs/pip-19.md](https://github.com/peacecoin-protocol/PIPs/blob/pip-19/PIPs/pip-19.md)

## Abstract

Soulbound Token（SBT / ERC-5192）をインターフェースとした Proof of Personhood を Arigato Creation アルゴリズムに統合する提案。コアプロトコル（PCEToken / PCECommunityToken）はSBT保有のみをチェックし、認証方法（Privado ID, World ID, SMS等）はMinterコントラクトに委譲することで、認証レイヤーを差し替え可能にする。

### Key Points

- **SBTベースのIF**: コアプロトコルは「SBTを持っているか」だけを見る。認証方法に依存しない
- **認証方法の差し替え可能**: Minterコントラクトを差し替えるだけでPCEToken/PCECommunityTokenの変更不要
- **複数Minter共存**: Privado ID, World ID, SMS, コミュニティ保証など複数の認証方法を同時運用可能
- **プロトコルレベル認証**: SBT保有 = 全コミュニティトークンで認証済み
- **アイデンティティ単位の日次制限**: 各コミュニティトークン内で`identityId`単位に適用
- **複数ウォレット対応**: 同一`identityId`で複数ウォレットにSBT発行可能

### Architecture

```
┌─ Verification Layer (swappable) ──────────────────┐
│  Privado ID / World ID / SMS / Community Vouching  │
│                     ▼                              │
│              Minter (MINTER_ROLE)                  │
└─────────────────────┬──────────────────────────────┘
                      ▼
               SBT Contract (ERC-5192)
               identityOf(wallet) → identityId
                      │
         ┌────────────┴────────────┐
         ▼                         ▼
     PCEToken              PCECommunityToken (×N)
  isPersonhoodVerified()   identityMintArigatoCreationToday
  personhoodBonusBp        (per-community, per-identity)
```

### SBT Interface

```solidity
interface IPCEPersonhood {
    function identityOf(address wallet) external view returns (uint256);
    function hasPersonhood(address wallet) external view returns (bool);
    function mint(address wallet, uint256 identityId) external;
    function burn(address wallet) external;
}
```

### Application Flow

```
初回認証:
1. ユーザーがアプリで「人間認証する」を押す
2. Minterが認証を実行（Privado ID ZKP, World ID, SMS等）
3. Minterが SBT.mint(wallet, identityId) を呼び出し
4. 全コミュニティトークンで即座に認証済み

ウォレット追加:
1. 別ウォレットから「ウォレット追加」
2. Minterが同一人物であることを確認
3. SBT.mint(newWallet, sameIdentityId)

以降の送金:
- 通常通り送金するだけ（追加操作不要）
```

---

<details>
<summary>日本語版 PIP 全文</summary>

## PIP-19: SBTベースの人間認証による Arigato Creation の改善

### 動機

現在の Arigato Creation アルゴリズムは、ウォレットアドレス単位で日次ミント上限を適用している。この設計はシビル攻撃に脆弱であり、1人の人間が複数のウォレットを作成して報酬を倍増させることが可能である。

Soulbound Token（SBT）ベースの人間認証を導入し、SBT保有者にはボーナスを与え、日次ミント上限をアイデンティティ単位で適用する。SBTをインターフェースとすることで、コアプロトコルは認証方法に一切依存せず、Minterコントラクトの差し替えだけで認証方法を変更できる。

### アーキテクチャ

コアプロトコル（PCEToken + PCECommunityToken）はSBTコントラクトのインターフェースのみに依存する。認証方法はMinterの実装詳細であり、独立してアップグレード・差し替え可能。

```
Verification Layer（差し替え可能）
  Privado ID / World ID / SMS / コミュニティ保証
                  ▼
           Minter（MINTER_ROLE）
                  ▼
          SBTコントラクト（ERC-5192）
          identityOf(wallet) → identityId
                  │
      ┌───────────┴───────────┐
      ▼                       ▼
  PCEToken            PCECommunityToken (×N)
  SBTアドレス保持      ID単位の日次ミント追跡
  認証状態照会         （コミュニティ間独立）
```

### SBTコントラクト（PCE Proof of Personhood Token）

ERC-5192（Minimal Soulbound NFTs）準拠の非譲渡トークン。

```solidity
interface IPCEPersonhood {
    function identityOf(address wallet) external view returns (uint256);
    function hasPersonhood(address wallet) external view returns (bool);
    function mint(address wallet, uint256 identityId) external;  // MINTER_ROLE only
    function burn(address wallet) external;  // owner or MINTER_ROLE
}
```

- **非譲渡**: transfer/transferFrom は常にrevert
- **1ウォレット1SBT**: 各ウォレットは最大1つのSBTを保持
- **共有identityId**: 同一人物の複数ウォレットは同じidentityIdでmint
- **認可制mint**: `MINTER_ROLE` を持つアドレスのみmint可能

### Minterコントラクト（認証レイヤー）

認証を実行し `SBT.mint()` を呼び出す責務。特定の認証プロバイダに依存する唯一のコンポーネント。

| Minter種別 | 認証方法 | 信頼レベル |
|-----------|---------|----------|
| Privado ID Minter | ZKP via UniversalVerifier | 高（推奨初期実装） |
| World ID Minter | 虹彩スキャン | 高（地域制限あり） |
| SMS Minter | 電話番号認証 | 中 |
| Community Minter | コミュニティオーナー保証 | 中-低 |

複数Minterを同時に認可可能。新Minterの追加・無効化はSBTコントラクトのアクセス制御で管理。

### PCEToken: SBT照会

```solidity
// ストレージ
address public personhoodSBT;
uint16 public personhoodBonusBp;

// 関数
function isPersonhoodVerified(address wallet) external view returns (bool);
function getIdentityId(address wallet) external view returns (uint256);
function setPersonhoodSBT(address sbt) external onlyOwner;
function setPersonhoodBonusBp(uint16 bonusBp) external onlyOwner;
```

`registerIdentity` / `unregisterIdentity` は不要 — SBT自体が登録状態。

### PCECommunityToken: アイデンティティ単位のミント追跡

各コミュニティトークンが独立して追跡:

```solidity
mapping(uint256 => uint256) public identityMintArigatoCreationToday;
mapping(uint256 => uint256) public identityLastMintResetTime;
```

### 変更後の Arigato Creation アルゴリズム

**ボーナス（SBT保有者）:**
```
increaseBp = maxIncreaseBp - (changeMulBp × messageBp) / BP_BASE
if (SBT保有):
    increaseBp = increaseBp + personhoodBonusBp
    increaseBp = min(increaseBp, maxIncreaseBp)
```

**アイデンティティ単位の日次制限（各コミュニティトークン内）:**
```
identityId = PCEToken.getIdentityId(sender)
identityMidnightBalance = 同一identityIdの全ウォレットのmidnightBalance合計
maxForIdentity = (maxArigatoCreationMintToday × identityMidnightBalance) / midnightTotalSupply
remainingForIdentity = max(0, maxForIdentity - identityMintArigatoCreationToday[identityId])
mintAmount = min(mintAmount, remainingForIdentity)
```

コミュニティAでのミントはコミュニティBの枠を消費しない。SBT非保有者は従来通り。

### アプリケーションフロー

**初回認証（1回のみ）:**
1. ユーザーがアプリで「人間認証する」を押す
2. Minterが認証を実行（Privado ID, World ID, SMS等はMinter実装次第）
3. MinterがSBT.mint(wallet, identityId)を呼び出し
4. 全コミュニティトークンで即座に認証済み

**ウォレット追加:**
1. 別ウォレットから「ウォレット追加」
2. Minterが同一人物であることを確認
3. SBT.mint(newWallet, sameIdentityId)

**以降の送金:** 通常通り。追加操作不要。

### 影響と互換性

- **後方互換**: 完全に後方互換。SBT非保有者は従来通り動作
- **プライバシー**: オンチェーンにはidentityId（匿名識別子）のみ。個人情報なし
- **ガス**: SBT mint ~50k gas（1回のみ）。送金時 ~5k gas追加（SBT照会）
- **ストレージ**: PCEToken/PCECommunityToken共に新mapping追加。既存レイアウト変更なし
- **差し替え可能**: 認証方法の変更 = Minterの差し替え。PCEToken/PCECommunityTokenの変更不要
- **コミュニティ間**: 各コミュニティトークンで独立した日次制限

### 設計根拠

- **SBTをIFにした理由**: コアプロトコルを認証方法から完全に切り離す。Minter差し替えだけで対応
- **ERC-5192の理由**: 最小限のSoulbound標準。ウォレット/マーケットプレイスが非譲渡を正しく表示
- **直接Privado ID/World IDを埋め込まなかった理由**: プロバイダAPI変更時にトークンコントラクトのアップグレードが必要になる
- **複数Minter共存の理由**: 地域やユーザー層に応じて最適な認証方法が異なる
- **複数ウォレット許容の理由**: ID単位キャップで経済的インセンティブ除去が効果的
- **ボーナス方式の理由**: 認証できない/しないユーザーを排除しない

### 備考

- 推奨初期Minter: Privado ID（UniversalVerifier: `0xfcc86A79fCb057A8e55C6B853dff9479C3cf607c`）
- `identityId` の生成戦略はMinter実装の詳細。Privado IDならZKPヌリファイアから導出可能
- クレデンシャルスキーマ・信頼Issuerリストはプロトコルレベルではなくminterレベルの設定

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)