### PR TITLE
PIP-20: Voucher-backed Discount Payments for Community Tokens

### DIFF
--- a/PIPs/pip-20.md
+++ b/PIPs/pip-20.md
@@ -1,0 +1,347 @@
+---
+pip: 20
+title: Voucher-backed Discount Payments for Community Tokens
+proposer: CHIBA Masahiro (@nihen)
+status: Draft
+type: Core
+created: 2026-05-29
+requires: [13]
+replaces: []
+---
+
+## PIP-20: Voucher-backed Discount Payments for Community Tokens
+
+### Abstract
+
+This proposal extends the existing community-token voucher mechanism so a voucher can be redeemed directly inside a merchant payment instead of being claimed as spendable balance by the user. A voucher issuance continues to represent locked community-token funds, a Merkle root of claim codes, a fixed `amountPerClaim`, per-user claim limits, total limits, and a validity window; the new payment flow sends the voucher amount to the merchant as a sponsor-funded discount while the buyer pays only the remaining amount.
+
+The extension deliberately avoids adding more `transferWithAuthorizationWith...` variants to `PCECommunityToken`. Instead, it adds one voucher-specific EIP-712 authorization that binds the buyer, merchant, issuance, code, payment amount, relayer, and nonce to a single atomic checkout.
+
+### Motivation
+
+The current voucher mechanism is a funded claim system. An issuance locks community tokens inside the `PCECommunityToken` contract and lets a user prove possession of a claim code using a Merkle proof. On success, the current `claimVoucher` path transfers `amountPerClaim` from the contract to the claimer.
+
+That is appropriate for token grants, but not for merchant discounts. In a merchant checkout, the desired settlement is:
+
+```text
+paymentAmount = userPaidAmount + discountAmount
+buyer -> merchant: userPaidAmount
+voucher locked funds -> merchant: discountAmount
+```
+
+For example, if a merchant charges 1,000 CT and the voucher amount is 200 CT, the buyer should pay 800 CT and the voucher pool should pay 200 CT. The merchant receives the full 1,000 CT in the same transaction.
+
+Using the current claim flow requires two separate steps: first claim the voucher to the buyer, then pay the merchant. That has three issues:
+
+1. The voucher can be claimed without any associated purchase.
+2. The merchant payment and sponsor subsidy are not atomic.
+3. Relayer and wallet integrations would be pushed toward adding more transfer variants such as `transferWithAuthorizationWithVoucher` or combinations with meta-transaction fee handling.
+
+PIP-20 changes the voucher redemption target for checkout use cases: the voucher amount goes directly to the merchant, and the buyer's signed authorization covers the whole payment context.
+
+### Specification
+
+#### Existing Concepts Reused
+
+The proposal builds on the current integrated voucher model in `PCECommunityToken` / `VoucherSystem`:
+
+```solidity
+struct VoucherIssuance {
+    string issuanceId;
+    address owner;
+    string name;
+    uint256 amountPerClaim;
+    uint256 countLimitPerUser;
+    uint256 totalAmountLimit;
+    uint256 startTime;
+    uint256 endTime;
+    bytes32 merkleRoot;
+    bool isActive;
+    string ipfsCid;
+}
+```
+
+The following existing state remains authoritative:
+
+```solidity
+mapping(string issuanceId => VoucherIssuance issuance) issuances;
+mapping(string issuanceId => mapping(address user => uint256 claimCount)) claimCountPerUser;
+mapping(string issuanceId => mapping(string issueCode => bool isUsed)) isCodeUsed;
+mapping(string issuanceId => uint256 remainingRawAmount) remainingRawAmount;
+mapping(string issuanceId => uint256 claimedRawAmount) claimedRawAmount;
+mapping(string issuanceId => uint256 claimedDisplayAmount) claimedDisplayAmount;
+mapping(string issuanceId => uint256 totalClaimCount) totalClaimCount;
+```
+
+For voucher-backed payments, `amountPerClaim` is interpreted as the fixed discount amount. `remainingRawAmount` is the remaining sponsor-funded voucher pool. `countLimitPerUser`, `totalAmountLimit`, `startTime`, `endTime`, `isActive`, `merkleRoot`, and `isCodeUsed` keep their existing meanings.
+
+#### Interface
+
+`PCECommunityToken` adds one public checkout entrypoint:
+
+```solidity
+function payWithVoucherAuthorization(
+    address buyer,
+    address merchant,
+    string memory issuanceId,
+    string memory code,
+    bytes32[] calldata proof,
+    uint256 paymentAmount,
+    address relayer,
+    uint256 validAfter,
+    uint256 validBefore,
+    bytes32 nonce,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+)
+    external
+    returns (uint256 userPaidAmount, uint256 discountAmount);
+```
+
+`buyer` is the wallet whose community-token balance pays the non-discounted part of the checkout. `merchant` is the recipient of both the buyer-paid amount and the voucher-funded amount. `paymentAmount` is the full merchant charge in display units. `discountAmount` is fixed to the issuance's `amountPerClaim`.
+
+The function MUST reject zero addresses for `buyer`, `merchant`, and `relayer`. The function MUST require `msg.sender == relayer`. For self-submitted payments, the buyer sets `relayer = buyer` and submits the transaction directly.
+
+#### EIP-712 Authorization
+
+`PCECommunityToken` adds a voucher-payment authorization typehash:
+
+```solidity
+bytes32 public constant PAY_WITH_VOUCHER_AUTHORIZATION_TYPEHASH = keccak256(
+    "PayWithVoucherAuthorization(address buyer,address merchant,string issuanceId,string code,uint256 paymentAmount,address relayer,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+);
+```
+
+The signed digest MUST use the existing `DOMAIN_SEPARATOR()` of the community token and the existing authorization-state mapping used by EIP-3009 style functions:
+
+```solidity
+_digest(abi.encode(
+    PAY_WITH_VOUCHER_AUTHORIZATION_TYPEHASH,
+    buyer,
+    merchant,
+    keccak256(bytes(issuanceId)),
+    keccak256(bytes(code)),
+    paymentAmount,
+    relayer,
+    validAfter,
+    validBefore,
+    nonce
+))
+```
+
+`payWithVoucherAuthorization` MUST:
+
+1. Require `block.timestamp > validAfter`.
+2. Require `block.timestamp < validBefore`.
+3. Require `_authorizationStates[buyer][nonce] == false`.
+4. Recover the signer from the digest and require it equals `buyer`.
+5. Set `_authorizationStates[buyer][nonce] = true`.
+6. Emit the existing `AuthorizationUsed(buyer, nonce)` event.
+
+The authorization binds the claim code to a specific buyer, merchant, full payment amount, relayer, validity window, and nonce. A third party that sees the code in calldata can copy the transaction but cannot redirect the discount to another merchant or change the buyer-paid amount.
+
+#### Payment Algorithm
+
+Let:
+
+```text
+discountAmount = issuance.amountPerClaim
+userPaidAmount = paymentAmount - discountAmount
+```
+
+The function MUST require `paymentAmount >= discountAmount`. PIP-20 keeps voucher discounts fixed-amount only and does not define partial voucher consumption. If the merchant charge is smaller than the voucher amount, the transaction MUST revert.
+
+The algorithm is:
+
+1. Call `updateFactorIfNeeded()`.
+2. Validate the EIP-712 authorization described above.
+3. Load the issuance and require it exists.
+4. Require `issuance.isActive == true`.
+5. Require `issuance.startTime == 0 || issuance.startTime < block.timestamp`.
+6. Require `issuance.endTime == 0 || block.timestamp < issuance.endTime`.
+7. Require `issuance.countLimitPerUser == 0 || claimCountPerUser[issuanceId][buyer] < issuance.countLimitPerUser`.
+8. Require the Merkle proof verifies `keccak256(abi.encodePacked(code))` against `issuance.merkleRoot`.
+9. Require `isCodeUsed[issuanceId][code] == false`.
+10. Compute `discountAmount = issuance.amountPerClaim` and require `paymentAmount >= discountAmount`.
+11. Convert `discountAmount` and `userPaidAmount` to raw units using `displayBalanceToRawBalance`.
+12. Require `remainingRawAmount[issuanceId] >= rawDiscountAmount`.
+13. If `issuance.totalAmountLimit > 0`, require `claimedDisplayAmount[issuanceId] + discountAmount <= issuance.totalAmountLimit`.
+14. Compute the relayer fee: if `relayer == buyer`, `displayFee = 0`; otherwise `displayFee = getMetaTransactionFee()`.
+15. Convert `displayFee` to raw units and require `balanceOf(buyer) >= rawUserPaidAmount + rawFee`.
+16. Increment `claimCountPerUser[issuanceId][buyer]`.
+17. Decrease `remainingRawAmount[issuanceId]` by `rawDiscountAmount`.
+18. Increase `claimedRawAmount[issuanceId]` by `rawDiscountAmount`.
+19. Increase `claimedDisplayAmount[issuanceId]` by `discountAmount`.
+20. Increase `totalClaimCount[issuanceId]` by 1.
+21. Set `isCodeUsed[issuanceId][code] = true`.
+22. If `rawUserPaidAmount > 0`, transfer `rawUserPaidAmount` from `buyer` to `merchant` using the host's internal transfer hook.
+23. Transfer `rawDiscountAmount` from `address(this)` to `merchant` using the host's internal transfer hook.
+24. If `displayFee > 0`, collect the relayer fee from `buyer` via `_collectFeeAsPCE(buyer, relayer, displayFee)`.
+25. Emit the events defined below.
+26. Return `(userPaidAmount, discountAmount)`.
+
+All state changes and transfers happen in one transaction. If any check or transfer fails, the buyer payment, voucher redemption, relayer fee collection, and usage markers all revert together.
+
+#### Events
+
+The existing `VoucherClaimed` event SHOULD continue to be emitted to preserve the current voucher indexing surface:
+
+```solidity
+event VoucherClaimed(
+    string indexed issuanceId,
+    address indexed claimer,
+    string code,
+    uint256 amount
+);
+```
+
+For voucher-backed checkout, `claimer` is `buyer` and `amount` is `discountAmount`.
+
+A new event is added for payment settlement:
+
+```solidity
+event VoucherPayment(
+    string indexed issuanceId,
+    address indexed buyer,
+    address indexed merchant,
+    string code,
+    uint256 paymentAmount,
+    uint256 userPaidAmount,
+    uint256 discountAmount,
+    address relayer
+);
+```
+
+The existing `AuthorizationUsed(buyer, nonce)` event MUST be emitted when the signed authorization is consumed. If a relayer fee is collected, the existing `MetaTransactionFeeCollected` and `MetaTransactionFeeSwapped` events from PIP-13 MUST be emitted by `_collectFeeAsPCE`.
+
+#### Library Placement
+
+The heavy logic SHOULD live in `VoucherSystem.sol`, following the existing pattern used by `registerVoucherIssuance`, `claimVoucher`, and `claimVoucherWithAuthorization`. `PCECommunityToken` should expose the public wrapper and pass `_voucherStorage` and `_authorizationStates` into the library.
+
+No new `transferWithAuthorizationWithVoucher`, `transferWithAuthorizationWithVoucherAndMeta`, or equivalent transfer-level function is introduced by this PIP.
+
+### Rationale
+
+**Why send the voucher amount directly to the merchant?**
+A discount voucher is not a token grant. The sponsor funds should subsidize a specific checkout. Sending the voucher amount directly to the merchant makes the subsidy inseparable from the purchase and prevents a user from claiming the subsidy as freely spendable balance without paying a merchant.
+
+**Why fixed amount only?**
+The current voucher system already has `amountPerClaim`. Reusing it as the fixed discount amount keeps the extension minimal and avoids new percentage, cap, or minimum-spend rule storage. More complex discount rules can be introduced later as a separate proposal.
+
+**Why require `paymentAmount >= amountPerClaim` instead of partially consuming a voucher?**
+Partial consumption would require either new per-code residual accounting or a rule that burns the unused portion. Both change the voucher semantics. PIP-20 keeps existing one-code-one-claim semantics: a code consumes exactly `amountPerClaim`, and checkouts below that amount are rejected.
+
+**Why require a voucher-payment authorization rather than a direct public payment function?**
+Voucher codes are bearer credentials. With the existing Merkle proof model, anyone who sees a valid `code + proof` pair can use it. In a public mempool, a direct `payWithVoucher(issuanceId, code, proof, merchant, amount)` call would reveal the code before confirmation; a frontrunner could redeem the same code to their own merchant address. The buyer's EIP-712 authorization binds the code to the buyer, merchant, payment amount, relayer, validity window, and nonce, so a copied transaction cannot redirect the discount.
+
+**Why include `relayer` in the signed data?**
+If the relayer were not signed, a frontrunner could copy the calldata and take the relayer fee. Binding `relayer` and requiring `msg.sender == relayer` makes the signed authorization usable only by the intended transaction submitter. For self-submission, the buyer signs `relayer = buyer` and no relayer fee is charged.
+
+**Why not extend `transferWithAuthorization`?**
+The payment needs voucher-specific context: issuance ID, code, proof, merchant, full payment amount, and relayer. Adding this to the generic transfer layer would create a family of specialized transfer functions and typehashes. Keeping the signature in the voucher subsystem preserves `transferWithAuthorization` as a simple token-transfer primitive and prevents function-combination growth.
+
+**Why reuse existing voucher storage?**
+The current voucher storage already tracks all required budget and usage state: locked funds, per-user counts, total claimed amounts, code usage, activity status, and validity windows. PIP-20 only changes the settlement destination for a checkout-specific redemption.
+
+### Backwards Compatibility
+
+This proposal is additive:
+
+- Existing `registerVoucherIssuance`, `claimVoucher`, `claimVoucherWithAuthorization`, `addVoucherFunds`, `withdrawVoucherFunds`, `terminateVoucherIssuance`, `getVoucherIssuanceInfo`, `getVoucherIssuanceIds`, and `canClaimVoucher` semantics remain unchanged.
+- Existing `transfer`, `transferFrom`, `transferWithAuthorization`, `transferFromWithAuthorization`, and meta-transaction fee functions remain unchanged.
+- No new voucher storage is required.
+- The existing `_authorizationStates` mapping is reused for the new voucher-payment authorization nonce.
+- Existing voucher issuances can be used for checkout discounts as long as their operational policy allows it. Applications that want to distinguish token-grant vouchers from payment-discount vouchers SHOULD use `ipfsCid` metadata and off-chain policy until a future proposal defines an on-chain issuance kind.
+
+Indexers that already process `VoucherClaimed` continue to observe a voucher redemption. Payment-aware indexers can additionally subscribe to `VoucherPayment`.
+
+### Test Cases
+
+Assume a community token `CT`, voucher issuance `summer-2026`, `amountPerClaim = 200 CT`, `countLimitPerUser = 1`, and sufficient `remainingRawAmount` unless stated otherwise.
+
+**Case 1: Standard discounted checkout**
+- Merchant charge: `paymentAmount = 1,000 CT`
+- Buyer authorization: buyer signs merchant, issuance ID, code, payment amount, relayer, validity window, and nonce
+- Result: `userPaidAmount = 800 CT`, `discountAmount = 200 CT`
+- Transfers: buyer pays `800 CT` to merchant; voucher locked funds pay `200 CT` to merchant
+- Merchant receives `1,000 CT`
+- `claimCountPerUser[issuanceId][buyer]` increments to 1
+- `isCodeUsed[issuanceId][code]` becomes true
+
+**Case 2: Voucher equals merchant charge**
+- Merchant charge: `paymentAmount = 200 CT`
+- Result: `userPaidAmount = 0`, `discountAmount = 200 CT`
+- Buyer pays no checkout amount, but still signs the payment authorization
+- Voucher locked funds pay `200 CT` to merchant
+
+**Case 3: Merchant charge below voucher amount**
+- Merchant charge: `paymentAmount = 150 CT`
+- Voucher amount: `200 CT`
+- Result: revert because `paymentAmount < amountPerClaim`
+- Code remains unused and funds remain locked
+
+**Case 4: Reused code**
+- The same code was already used in Case 1
+- A second call with the same code reverts with `Code already used`
+- No payment or fee is collected
+
+**Case 5: Wrong merchant**
+- Buyer signs authorization for merchant A
+- A third party submits the same code and signature with merchant B
+- Result: signature recovery fails because `merchant` is part of the signed digest
+
+**Case 6: Wrong relayer**
+- Buyer signs authorization with `relayer = R1`
+- `R2` submits the transaction
+- Result: revert because `msg.sender != relayer`
+- This prevents relayer-fee theft by calldata copying
+
+**Case 7: Relayed checkout with fee**
+- Buyer signs with `relayer = R1`
+- `R1` submits the transaction
+- `getMetaTransactionFee()` returns `0.002 CT`
+- Result: buyer pays `800 CT` to merchant and `0.002 CT` equivalent fee via `_collectFeeAsPCE`; voucher locked funds pay `200 CT` to merchant; relayer receives PCE according to PIP-13
+
+**Case 8: Insufficient buyer balance**
+- Buyer has `799 CT` and relayer fee is zero
+- Merchant charge is `1,000 CT`, voucher amount is `200 CT`
+- Required buyer amount is `800 CT`
+- Result: revert; voucher code remains unused
+
+**Case 9: Insufficient voucher funds**
+- `remainingRawAmount[issuanceId]` is less than the raw equivalent of `200 CT`
+- Result: revert; buyer balance is unchanged and code remains unused
+
+### Security Considerations
+
+**Bearer-code leakage and front-running.** Voucher codes are bearer credentials under the current `keccak256(abi.encodePacked(code))` Merkle leaf model. PIP-20 therefore uses a buyer-signed voucher-payment authorization and does not rely on a bare public payment call. The signed digest binds the code to a buyer, merchant, payment amount, relayer, validity window, and nonce. A transaction copier can only submit the same authorized payment to the same merchant; they cannot redirect the voucher value.
+
+**Relayer-fee theft.** The `relayer` address is signed and `msg.sender == relayer` is required. A third party cannot copy the transaction and collect the relayer fee.
+
+**Atomicity.** Buyer payment, voucher subsidy, code usage, per-user count, total claimed counters, and relayer fee collection occur in one transaction. Any failure reverts all effects.
+
+**Replay protection.** The existing `_authorizationStates[buyer][nonce]` mapping MUST be used. Once consumed, the same buyer nonce cannot authorize another voucher payment.
+
+**Merchant spoofing.** The merchant address is part of the signed digest and is emitted in `VoucherPayment`. Wallets MUST display the merchant address or a verified merchant name before requesting the buyer signature.
+
+**Code privacy.** Codes still appear in transaction calldata. Applications SHOULD submit voucher payments through the signed relayer flow and SHOULD avoid exposing unused codes to untrusted systems before the buyer authorization is created. Issuers that require stronger privacy or wallet binding SHOULD use off-chain distribution controls or propose a future leaf format that includes the buyer address.
+
+**Rounding.** `discountAmount`, `userPaidAmount`, and relayer fee are display-unit values converted to raw units using the community token's existing factor conversion. Implementations MUST use the same conversion functions used by existing voucher claims and transfers. Rounding follows current token behavior.
+
+**Contract balance accounting.** The voucher discount is paid from `address(this)`, which holds locked voucher funds. Implementations MUST check `remainingRawAmount[issuanceId] >= rawDiscountAmount` before transferring. The function MUST NOT pay discounts from unrelated user balances.
+
+**Scope of authorization.** The new authorization is not a general-purpose transfer authorization. It only authorizes this voucher payment. Implementations MUST NOT expose a way to reuse the signature for ordinary transfers.
+
+### Notes
+
+- Related prototype: https://github.com/peacecoin-protocol/erc20-voucher/tree/feature/initial
+- Related core implementation surface: `PCECommunityToken` voucher functions and `VoucherSystem.sol` in https://github.com/peacecoin-protocol/core
+- Requires PIP-13 when the relayed path charges and auto-swaps meta-transaction fees to PCE.
+- Out of scope: percentage discounts, maximum-discount caps, minimum purchase amounts, partial voucher consumption, on-chain merchant allowlists, wallet-bound Merkle leaves, and a separate `PaymentRouter` contract.
+- Out of scope: changing existing token-grant voucher behavior. `claimVoucher` and `claimVoucherWithAuthorization` remain valid for token-grant campaigns.
+- Future extension: an on-chain `issuanceKind` field could distinguish `TOKEN_GRANT` and `PAYMENT_DISCOUNT` campaigns. PIP-20 does not require it because the current `ipfsCid` metadata field can carry operational policy without a storage change.
+
+### Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

- Add PIP-20: Voucher-backed Discount Payments for Community Tokens
- **PIP full text**: [PIPs/pip-20.md](https://github.com/peacecoin-protocol/PIPs/blob/pip-20-voucher-payment/PIPs/pip-20.md)
- Related prototype: [peacecoin-protocol/erc20-voucher](https://github.com/peacecoin-protocol/erc20-voucher/tree/feature/initial)
- Related implementation surface: `PCECommunityToken` voucher functions and `VoucherSystem.sol` in [peacecoin-protocol/core](https://github.com/peacecoin-protocol/core)

## Abstract

This proposal extends the existing community-token voucher mechanism so a voucher can be redeemed directly inside a payment instead of being claimed as spendable balance by the user. A voucher issuance continues to represent locked community-token funds, a Merkle root of claim codes, a fixed `amountPerClaim`, per-user claim limits, total limits, and a validity window; the new payment flow sends the voucher amount to the recipient as a sponsor-funded discount while the buyer pays only the remaining amount.

The extension deliberately avoids adding more `transferWithAuthorizationWith...` variants to `PCECommunityToken`. Instead, it adds one voucher-specific EIP-712 authorization that binds the buyer, recipient, issuance, code, payment amount, relayer, and nonce to a single atomic checkout.

### Key Points

- **Voucher amount becomes fixed discount**: existing `amountPerClaim` is reused as the fixed discount amount.
- **Sponsor-funded recipient settlement**: buyer pays `paymentAmount - amountPerClaim`; locked voucher funds pay `amountPerClaim`; recipient receives the full `paymentAmount` in one transaction.
- **No transfer-function explosion**: the proposal does not add `transferWithAuthorizationWithVoucher` or combined transfer/meta/voucher variants.
- **Voucher-specific EIP-712 authorization**: buyer signs recipient, issuance ID, code, payment amount, relayer, validity window, and nonce.
- **Bearer-code front-running mitigation**: copied calldata cannot redirect the voucher to another recipient because recipient and relayer are signed.
- **Existing storage reused**: `VoucherIssuance`, `remainingRawAmount`, `claimedRawAmount`, `claimedDisplayAmount`, `claimCountPerUser`, and `isCodeUsed` remain authoritative.
- **PIP-13 integration**: relayed checkout can collect the meta-transaction fee from the buyer and auto-swap it to PCE for the relayer.
- **Strict fixed amount**: partial voucher consumption is out of scope; `paymentAmount < amountPerClaim` reverts.

### Settlement Example

```text
Payment amount: 1,000 CT
Voucher amount: 200 CT
Buyer payment: 800 CT
Voucher subsidy: 200 CT
Recipient receives: 1,000 CT
```

### Security Notes

The proposal treats claim codes as bearer credentials under the current `keccak256(abi.encodePacked(code))` Merkle leaf model. For checkout use, it therefore requires a buyer-signed voucher-payment authorization rather than a bare public payment function. The signed digest binds the code to a specific buyer, recipient, payment amount, relayer, validity window, and nonce.

---

<details><summary>日本語版 PIP 全文</summary>

---
pip: 20
title: Voucher-backed Discount Payments for Community Tokens
proposer: CHIBA Masahiro (@nihen)
status: Draft
type: Core
created: 2026-05-29
requires: [13]
replaces: []
---

## PIP-20: コミュニティトークン向け Voucher 補填型割引決済

### Abstract（要約）

本提案は、既存のコミュニティトークン voucher 機構を拡張し、voucher をユーザーへの残高付与ではなく、決済の中で直接利用できるようにする。Voucher issuance は引き続き、ロックされたコミュニティトークン原資、claim code の Merkle root、固定額 `amountPerClaim`、ユーザーごとの利用回数制限、総量制限、有効期間を表す。新しい決済フローでは、voucher 額がスポンサー補填分として受取人に直接送られ、buyer は残額だけを支払う。

この拡張では、`PCECommunityToken` に `transferWithAuthorizationWith...` 系の関数をさらに増やさない。代わりに、buyer、recipient、issuance、code、payment amount、relayer、nonce を 1 つの atomic checkout に束縛する voucher 専用の EIP-712 authorization を追加する。

### Motivation（動機）

現在の voucher 機構は、原資付き claim system である。Issuance は community token を `PCECommunityToken` contract 内にロックし、ユーザーが claim code を持っていることを Merkle proof で証明できる。成功すると、現在の `claimVoucher` 経路は `amountPerClaim` を contract から claimer に transfer する。

これは token grant には適しているが、割引決済には適していない。checkout で必要な settlement は次の形である。

```text
paymentAmount = userPaidAmount + discountAmount
buyer -> recipient: userPaidAmount
voucher locked funds -> recipient: discountAmount
```

例えば、請求額が 1,000 CT で voucher 額が 200 CT の場合、buyer は 800 CT を支払い、voucher pool は 200 CT を支払う。受取人は同一 transaction で 1,000 CT 全額を受け取る。

現在の claim flow を使うと、まず voucher を buyer に claim し、その後 recipient に支払う 2 段階になる。この方法には 3 つの問題がある。

1. Voucher が購入と紐づかず、自由に使える残高として claim できる。
2. Payment と sponsor subsidy が atomic ではない。
3. Relayer / wallet integration が、`transferWithAuthorizationWithVoucher` や meta-transaction fee との組み合わせ関数を増やす方向に押しやられる。

PIP-20 は checkout 用途における voucher redemption の送付先を変更する。Voucher 額は直接 recipient に送られ、buyer の署名 authorization は決済文脈全体をカバーする。

### Specification（仕様）

#### Existing Concepts Reused（再利用する既存概念）

本提案は、現在の `PCECommunityToken` / `VoucherSystem` に統合された voucher model を前提にする。

```solidity
struct VoucherIssuance {
    string issuanceId;
    address owner;
    string name;
    uint256 amountPerClaim;
    uint256 countLimitPerUser;
    uint256 totalAmountLimit;
    uint256 startTime;
    uint256 endTime;
    bytes32 merkleRoot;
    bool isActive;
    string ipfsCid;
}
```

次の既存 state が引き続き正とされる。

```solidity
mapping(string issuanceId => VoucherIssuance issuance) issuances;
mapping(string issuanceId => mapping(address user => uint256 claimCount)) claimCountPerUser;
mapping(string issuanceId => mapping(string issueCode => bool isUsed)) isCodeUsed;
mapping(string issuanceId => uint256 remainingRawAmount) remainingRawAmount;
mapping(string issuanceId => uint256 claimedRawAmount) claimedRawAmount;
mapping(string issuanceId => uint256 claimedDisplayAmount) claimedDisplayAmount;
mapping(string issuanceId => uint256 totalClaimCount) totalClaimCount;
```

Voucher-backed payment では、`amountPerClaim` を固定割引額として解釈する。`remainingRawAmount` は残りの sponsor-funded voucher pool を表す。`countLimitPerUser`、`totalAmountLimit`、`startTime`、`endTime`、`isActive`、`merkleRoot`、`isCodeUsed` は既存と同じ意味を保つ。

#### Interface（インターフェース）

`PCECommunityToken` に 1 つの checkout entrypoint を追加する。

```solidity
function payWithVoucherAuthorization(
    address buyer,
    address recipient,
    string memory issuanceId,
    string memory code,
    bytes32[] calldata proof,
    uint256 paymentAmount,
    address relayer,
    uint256 validAfter,
    uint256 validBefore,
    bytes32 nonce,
    uint8 v,
    bytes32 r,
    bytes32 s
)
    external
    returns (uint256 userPaidAmount, uint256 discountAmount);
```

`buyer` は checkout の非割引部分を支払う community-token wallet である。`recipient` は buyer 支払い分と voucher 補填分の両方を受け取るアドレスである。`paymentAmount` は display unit で表した全請求額である。`discountAmount` は issuance の `amountPerClaim` に固定される。

この関数は、`buyer`、`recipient`、`relayer` が zero address である場合に reject しなければならない（MUST）。また、`msg.sender == relayer` を要求しなければならない（MUST）。Buyer が自分で transaction を送信する場合、`relayer = buyer` として署名し、自分で transaction を submit する。

#### EIP-712 Authorization（EIP-712 承認）

`PCECommunityToken` に voucher payment authorization typehash を追加する。

```solidity
bytes32 public constant PAY_WITH_VOUCHER_AUTHORIZATION_TYPEHASH = keccak256(
    "PayWithVoucherAuthorization(address buyer,address recipient,string issuanceId,string code,uint256 paymentAmount,address relayer,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
);
```

署名 digest は、community token の既存 `DOMAIN_SEPARATOR()` と、EIP-3009 系関数で使われている既存 authorization-state mapping を使わなければならない。

```solidity
_digest(abi.encode(
    PAY_WITH_VOUCHER_AUTHORIZATION_TYPEHASH,
    buyer,
    recipient,
    keccak256(bytes(issuanceId)),
    keccak256(bytes(code)),
    paymentAmount,
    relayer,
    validAfter,
    validBefore,
    nonce
))
```

`payWithVoucherAuthorization` は次を満たさなければならない。

1. `block.timestamp > validAfter` を要求する。
2. `block.timestamp < validBefore` を要求する。
3. `_authorizationStates[buyer][nonce] == false` を要求する。
4. Digest から signer を recover し、`buyer` と一致することを要求する。
5. `_authorizationStates[buyer][nonce] = true` を設定する。
6. 既存の `AuthorizationUsed(buyer, nonce)` event を emit する。

この authorization は、claim code を特定の buyer、recipient、full payment amount、relayer、有効期間、nonce に束縛する。Calldata 上で code を見た第三者は transaction をコピーできるが、discount を別の recipient に向けたり、buyer-paid amount を変更したりできない。

#### Payment Algorithm（決済アルゴリズム）

以下を定義する。

```text
discountAmount = issuance.amountPerClaim
userPaidAmount = paymentAmount - discountAmount
```

この関数は `paymentAmount >= discountAmount` を要求しなければならない（MUST）。PIP-20 は fixed-amount discount のみを扱い、partial voucher consumption は定義しない。Payment amount が voucher amount より小さい場合、transaction は revert しなければならない（MUST）。

アルゴリズムは次の通り。

1. `updateFactorIfNeeded()` を呼ぶ。
2. 上記 EIP-712 authorization を検証する。
3. Issuance を読み込み、存在を要求する。
4. `issuance.isActive == true` を要求する。
5. `issuance.startTime == 0 || issuance.startTime < block.timestamp` を要求する。
6. `issuance.endTime == 0 || block.timestamp < issuance.endTime` を要求する。
7. `issuance.countLimitPerUser == 0 || claimCountPerUser[issuanceId][buyer] < issuance.countLimitPerUser` を要求する。
8. `keccak256(abi.encodePacked(code))` が `issuance.merkleRoot` に含まれることを Merkle proof で検証する。
9. `isCodeUsed[issuanceId][code] == false` を要求する。
10. `discountAmount = issuance.amountPerClaim` を計算し、`paymentAmount >= discountAmount` を要求する。
11. `discountAmount` と `userPaidAmount` を `displayBalanceToRawBalance` で raw unit に変換する。
12. `remainingRawAmount[issuanceId] >= rawDiscountAmount` を要求する。
13. `issuance.totalAmountLimit > 0` の場合、`claimedDisplayAmount[issuanceId] + discountAmount <= issuance.totalAmountLimit` を要求する。
14. Relayer fee を計算する。`relayer == buyer` の場合は `displayFee = 0`、それ以外の場合は `displayFee = getMetaTransactionFee()` とする。
15. `displayFee` を raw unit に変換し、`balanceOf(buyer) >= rawUserPaidAmount + rawFee` を要求する。
16. `claimCountPerUser[issuanceId][buyer]` を increment する。
17. `remainingRawAmount[issuanceId]` を `rawDiscountAmount` だけ減らす。
18. `claimedRawAmount[issuanceId]` を `rawDiscountAmount` だけ増やす。
19. `claimedDisplayAmount[issuanceId]` を `discountAmount` だけ増やす。
20. `totalClaimCount[issuanceId]` を 1 増やす。
21. `isCodeUsed[issuanceId][code] = true` を設定する。
22. `rawUserPaidAmount > 0` の場合、host の internal transfer hook を使って `buyer` から `recipient` に `rawUserPaidAmount` を transfer する。
23. Host の internal transfer hook を使って `address(this)` から `recipient` に `rawDiscountAmount` を transfer する。
24. `displayFee > 0` の場合、`_collectFeeAsPCE(buyer, relayer, displayFee)` により buyer から relayer fee を徴収する。
25. 後述の events を emit する。
26. `(userPaidAmount, discountAmount)` を返す。

すべての state changes と transfers は 1 transaction 内で実行される。任意の check または transfer が失敗した場合、buyer payment、voucher redemption、relayer fee collection、usage markers はすべて一緒に revert する。

#### Events（イベント）

現在の voucher indexing surface を維持するため、既存の `VoucherClaimed` event は引き続き emit されるべきである（SHOULD）。

```solidity
event VoucherClaimed(
    string indexed issuanceId,
    address indexed claimer,
    string code,
    uint256 amount
);
```

Voucher-backed checkout では、`claimer` は `buyer`、`amount` は `discountAmount` である。

Payment settlement 用に新しい event を追加する。

```solidity
event VoucherPayment(
    string indexed issuanceId,
    address indexed buyer,
    address indexed recipient,
    string code,
    uint256 paymentAmount,
    uint256 userPaidAmount,
    uint256 discountAmount,
    address relayer
);
```

署名 authorization が消費されたとき、既存の `AuthorizationUsed(buyer, nonce)` event を emit しなければならない（MUST）。Relayer fee が徴収された場合、PIP-13 の `_collectFeeAsPCE` により既存の `MetaTransactionFeeCollected` と `MetaTransactionFeeSwapped` events を emit しなければならない（MUST）。

#### Library Placement（ライブラリ配置）

重いロジックは、`registerVoucherIssuance`、`claimVoucher`、`claimVoucherWithAuthorization` と同じ既存 pattern に従い、`VoucherSystem.sol` に置くべきである（SHOULD）。`PCECommunityToken` は public wrapper を公開し、`_voucherStorage` と `_authorizationStates` を library に渡す。

本 PIP では、`transferWithAuthorizationWithVoucher`、`transferWithAuthorizationWithVoucherAndMeta`、または同等の transfer-level function を追加しない。

### Rationale（設計根拠）

**なぜ voucher 額を直接 recipient に送るのか？**
Discount voucher は token grant ではない。Sponsor funds は特定の checkout を補助するべきである。Voucher 額を直接 recipient に送ることで、subsidy を購入と不可分にし、ユーザーが subsidy を自由に使える残高として受け取ることを防ぐ。

**なぜ fixed amount のみか？**
現在の voucher system はすでに `amountPerClaim` を持っている。これを fixed discount amount として再利用することで、拡張を最小化し、percentage、cap、minimum-spend rule 用の新 storage を避ける。より複雑な discount rules は、後続提案で導入できる。

**なぜ `paymentAmount >= amountPerClaim` を要求し、partial consumption をしないのか？**
Partial consumption は per-code residual accounting を追加するか、未使用部分を burn する rule を導入する必要がある。どちらも voucher semantics を変える。PIP-20 は既存の one-code-one-claim semantics を維持する。つまり、1 code は正確に `amountPerClaim` を消費し、それ未満の checkout は reject される。

**なぜ direct public payment function ではなく voucher-payment authorization を要求するのか？**
Voucher code は bearer credential である。既存の Merkle proof model では、valid な `code + proof` を見た人は誰でも使える。Public mempool で `payWithVoucher(issuanceId, code, proof, recipient, amount)` のような direct call を送ると、confirmation 前に code が公開される。Frontrunner は同じ code を自分の address に redeem できる。Buyer の EIP-712 authorization は、code を buyer、recipient、payment amount、relayer、有効期間、nonce に束縛するため、copy された transaction では voucher value を redirect できない。

**なぜ `relayer` を signed data に含めるのか？**
Relayer が署名に含まれていない場合、frontrunner は calldata をコピーして relayer fee を奪える。`relayer` を bind し、`msg.sender == relayer` を要求することで、署名 authorization は意図された transaction submitter だけが利用できる。Self-submission の場合、buyer は `relayer = buyer` として署名し、relayer fee は徴収されない。

**なぜ `transferWithAuthorization` を拡張しないのか？**
この payment は voucher-specific context、つまり issuance ID、code、proof、recipient、full payment amount、relayer を必要とする。これらを generic transfer layer に追加すると、specialized transfer functions と typehashes の系列が増える。Signature を voucher subsystem に閉じ込めることで、`transferWithAuthorization` を単純な token-transfer primitive として保ち、function-combination growth を防ぐ。

**なぜ既存 voucher storage を再利用するのか？**
現在の voucher storage は、locked funds、per-user counts、total claimed amounts、code usage、activity status、validity windows という必要な budget / usage state をすでに追跡している。PIP-20 は checkout-specific redemption の settlement destination を変えるだけである。

### Backwards Compatibility（後方互換性）

本提案は追加的変更である。

- 既存の `registerVoucherIssuance`、`claimVoucher`、`claimVoucherWithAuthorization`、`addVoucherFunds`、`withdrawVoucherFunds`、`terminateVoucherIssuance`、`getVoucherIssuanceInfo`、`getVoucherIssuanceIds`、`canClaimVoucher` の semantics は変更しない。
- 既存の `transfer`、`transferFrom`、`transferWithAuthorization`、`transferFromWithAuthorization`、meta-transaction fee functions は変更しない。
- 新しい voucher storage は不要。
- 新しい voucher-payment authorization nonce には既存の `_authorizationStates` mapping を再利用する。
- 既存の voucher issuance は、運用 policy が許可する限り checkout discount に利用できる。Token-grant voucher と payment-discount voucher を区別したい application は、future proposal が on-chain issuance kind を定義するまで、`ipfsCid` metadata と off-chain policy を使うべきである（SHOULD）。

既存の `VoucherClaimed` を処理する indexer は、引き続き voucher redemption を観測できる。Payment-aware indexer は追加で `VoucherPayment` を subscribe できる。

### Test Cases（テストケース）

Community token `CT`、voucher issuance `summer-2026`、`amountPerClaim = 200 CT`、`countLimitPerUser = 1` とする。特記がない限り、`remainingRawAmount` は十分にある。

**Case 1: 標準的な割引 checkout**
- Payment amount: `paymentAmount = 1,000 CT`
- Buyer authorization: buyer は recipient、issuance ID、code、payment amount、relayer、有効期間、nonce に署名する
- Result: `userPaidAmount = 800 CT`、`discountAmount = 200 CT`
- Transfers: buyer は recipient に `800 CT` を支払い、voucher locked funds は recipient に `200 CT` を支払う
- Recipient は `1,000 CT` を受け取る
- `claimCountPerUser[issuanceId][buyer]` は 1 に increment される
- `isCodeUsed[issuanceId][code]` は true になる

**Case 2: Voucher 額が payment amount と等しい**
- Payment amount: `paymentAmount = 200 CT`
- Result: `userPaidAmount = 0`、`discountAmount = 200 CT`
- Buyer は checkout amount を支払わないが、payment authorization には署名する
- Voucher locked funds は recipient に `200 CT` を支払う

**Case 3: Payment amount が voucher amount より小さい**
- Payment amount: `paymentAmount = 150 CT`
- Voucher amount: `200 CT`
- Result: `paymentAmount < amountPerClaim` のため revert
- Code は unused のままで、funds は locked のまま

**Case 4: Reused code**
- 同じ code が Case 1 ですでに使われている
- 同じ code で 2 回目の call を行うと `Code already used` で revert
- Payment も fee も徴収されない

**Case 5: Wrong recipient**
- Buyer は recipient A に対して authorization を署名する
- 第三者が同じ code と signature を recipient B に差し替えて submit する
- Result: `recipient` が signed digest に含まれるため、signature recovery が失敗する

**Case 6: Wrong relayer**
- Buyer は `relayer = R1` として authorization を署名する
- `R2` が transaction を submit する
- Result: `msg.sender != relayer` のため revert
- Calldata copying による relayer-fee theft を防ぐ

**Case 7: Fee 付き relayed checkout**
- Buyer は `relayer = R1` として署名する
- `R1` が transaction を submit する
- `getMetaTransactionFee()` は `0.002 CT` を返す
- Result: buyer は recipient に `800 CT` を支払い、`_collectFeeAsPCE` 経由で `0.002 CT` 相当の fee を支払う。Voucher locked funds は recipient に `200 CT` を支払う。Relayer は PIP-13 に従って PCE を受け取る

**Case 8: Buyer balance 不足**
- Buyer は `799 CT` を持ち、relayer fee は 0
- Payment amount は `1,000 CT`、voucher amount は `200 CT`
- Buyer に必要な amount は `800 CT`
- Result: revert。Voucher code は unused のまま

**Case 9: Voucher funds 不足**
- `remainingRawAmount[issuanceId]` が `200 CT` の raw equivalent 未満
- Result: revert。Buyer balance は変化せず、code も unused のまま

### Security Considerations（セキュリティ考慮事項）

**Bearer-code leakage と front-running。** 現在の `keccak256(abi.encodePacked(code))` Merkle leaf model では、voucher code は bearer credential である。そのため PIP-20 は buyer-signed voucher-payment authorization を使い、bare public payment call に依存しない。Signed digest は code を buyer、recipient、payment amount、relayer、有効期間、nonce に束縛する。Transaction copier は同じ authorized payment を同じ recipient に submit できるだけで、voucher value を redirect できない。

**Relayer-fee theft。** `relayer` address は署名され、`msg.sender == relayer` が要求される。第三者は transaction をコピーして relayer fee を受け取れない。

**Atomicity。** Buyer payment、voucher subsidy、code usage、per-user count、total claimed counters、relayer fee collection は 1 transaction で実行される。任意の failure はすべての effects を revert する。

**Replay protection。** 既存の `_authorizationStates[buyer][nonce]` mapping を使わなければならない（MUST）。一度消費された buyer nonce は、別の voucher payment に再利用できない。

**Recipient spoofing。** Recipient address は signed digest に含まれ、`VoucherPayment` に emit される。Wallets は buyer signature を要求する前に recipient address または verified name を表示しなければならない（MUST）。

**Code privacy。** Code は引き続き transaction calldata に現れる。Applications は signed relayer flow で voucher payment を submit すべきであり（SHOULD）、buyer authorization が作成される前に unused code を untrusted systems に公開すべきではない（SHOULD NOT）。より強い privacy または wallet binding を必要とする issuer は、off-chain distribution controls を使うか、buyer address を含む leaf format を future proposal として提案すべきである。

**Rounding。** `discountAmount`、`userPaidAmount`、relayer fee は display-unit values であり、community token の既存 factor conversion により raw unit に変換される。実装は existing voucher claims and transfers と同じ conversion functions を使わなければならない（MUST）。Rounding は現在の token behavior に従う。

**Contract balance accounting。** Voucher discount は、locked voucher funds を保持する `address(this)` から支払われる。実装は transfer 前に `remainingRawAmount[issuanceId] >= rawDiscountAmount` を check しなければならない（MUST）。この関数は unrelated user balances から discount を支払ってはならない（MUST NOT）。

**Scope of authorization。** 新しい authorization は general-purpose transfer authorization ではない。この voucher payment のみを authorize する。実装は、この signature を ordinary transfers に再利用できる経路を公開してはならない（MUST NOT）。

### Notes（補足）

- Related prototype: https://github.com/peacecoin-protocol/erc20-voucher/tree/feature/initial
- Related core implementation surface: https://github.com/peacecoin-protocol/core の `PCECommunityToken` voucher functions と `VoucherSystem.sol`
- Relayed path が meta-transaction fee を PCE に auto-swap する場合、PIP-13 に依存する。
- Scope out: percentage discounts、maximum-discount caps、minimum purchase amounts、partial voucher consumption、on-chain recipient allowlists、wallet-bound Merkle leaves、separate `PaymentRouter` contract。
- Scope out: 既存 token-grant voucher behavior の変更。`claimVoucher` と `claimVoucherWithAuthorization` は token-grant campaign 用として引き続き有効。
- Future extension: on-chain `issuanceKind` field により `TOKEN_GRANT` と `PAYMENT_DISCOUNT` campaign を区別できる。PIP-20 では storage change を避けるためこれを必須にしない。現在の `ipfsCid` metadata field で operational policy を持てる。

### Copyright（著作権）

Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

</details>

