### PR TITLE
PIP-21: Path-Consistent Community Token Decay Factor

### DIFF
--- a/PIPs/pip-21.md
+++ b/PIPs/pip-21.md
@@ -1,0 +1,288 @@
+---
+pip: 21
+title: Path-Consistent Community Token Decay Factor
+proposer: CHIBA Masahiro (@nihen)
+status: Draft
+type: Core
+created: 2026-06-17
+requires: []
+replaces: []
+---
+
+## PIP-21: Path-Consistent Community Token Decay Factor
+
+### Abstract
+
+This proposal fixes the current behavior in which community-token decay depends on how often `updateFactorIfNeeded()` is executed. It changes the multi-period decay calculation of `PCECommunityToken.getCurrentFactor()` so that the per-period community-token decay rate is exponentiated at WAD precision (`1e18`) instead of basis-point precision (`10000`), keeping batched multi-period calculation aligned with period-by-period materialization up to WAD rounding. It also adds the missing `afterDecreaseBp <= 10000` validation to `PCECommunityToken.setTokenSettings` and requires governance to materialize the current factor of every existing token before the implementation upgrade.
+
+### Motivation
+
+Community-token decay should be path-consistent: for the same settings and the same elapsed period count, the result should not materially depend on transaction frequency or on how often `updateFactorIfNeeded()` is called. The current implementation violates this invariant. Materializing the factor once per decay period and computing several elapsed periods in one `getCurrentFactor()` call can produce different results.
+
+Community-token decay is configured by `afterDecreaseBp`, for example `9980` for a 99.8% remaining balance per decay period. The current implementation converts the final result to WAD, but exponentiation-by-squaring squares the rate while it is still represented in basis points:
+
+```solidity
+uint256 rate = afterDecreaseBp;
+uint256 base = BP_BASE;
+rate = Math.mulDiv(rate, rate, base);
+```
+
+For `afterDecreaseBp = 9980`, the first squaring computes `9980 * 9980 / 10000 = 9960` after integer truncation, while the mathematically configured two-period value is `0.998^2 = 0.996004`. Under the current implementation, materializing the factor once per decay period and computing several elapsed periods in one `getCurrentFactor()` call are therefore not equivalent: the batched calculation uses BP-truncated squared rates. The more periods that are batched into one calculation, the more over-decay accumulates relative to the configured rate.
+
+### Specification
+
+#### Scope
+
+This proposal changes only the community-token decay factor calculation and `setTokenSettings` validation. The primary goal is to remove the current behavior where multi-period decay materially depends on transaction cadence / materialization cadence; WAD precision is the implementation mechanism. It does not change PCE Token decay, swap formulas, ARIGATO CREATION, voucher logic, token balances, storage layout, or event schemas.
+
+#### Constants
+
+Existing constants keep their current meanings:
+
+```solidity
+uint256 public constant INITIAL_FACTOR = 10 ** 18;
+uint256 public constant BP_BASE = 10_000;
+```
+
+`INITIAL_FACTOR` is the WAD base used by display/raw balance conversion. `BP_BASE` is the input scale of basis-point configuration values.
+
+#### PCECommunityToken.getCurrentFactor
+
+The implementation MUST convert `afterDecreaseBp` to WAD precision before exponentiation-by-squaring:
+
+```solidity
+function getCurrentFactor() public view returns (uint256);
+```
+
+The multi-period section MUST be equivalent to:
+
+```solidity
+uint256 times = elapsed / decreaseIntervalDays;
+uint256 factor = lastModifiedFactor;
+uint256 rate = Math.mulDiv(afterDecreaseBp, INITIAL_FACTOR, BP_BASE);
+uint256 base = INITIAL_FACTOR;
+uint256 n = times;
+
+while (n > 0) {
+    if (n % 2 == 1) {
+        factor = Math.mulDiv(factor, rate, base);
+    }
+    rate = Math.mulDiv(rate, rate, base);
+    n /= 2;
+}
+
+return factor;
+```
+
+All existing guard behavior remains unchanged:
+
+1. If `lastModifiedFactor == 0`, return `0`.
+2. If `decreaseIntervalDays == 0`, return `lastModifiedFactor`.
+3. If no UTC day boundary has passed since `lastDecreaseTime`, return `lastModifiedFactor`.
+4. If the elapsed day count is less than `decreaseIntervalDays`, return `lastModifiedFactor`.
+
+#### PCECommunityToken.setTokenSettings
+
+The following existing function MUST reject a decay setting above 100%:
+
+```solidity
+function setTokenSettings(
+    uint256 _decreaseIntervalDays,
+    uint16 _afterDecreaseBp,
+    uint16 _maxIncreaseOfTotalSupplyBp,
+    uint16 _maxIncreaseBp,
+    uint16 _maxUsageBp,
+    uint16 _changeBp,
+    ExchangeAllowMethod _incomeExchangeAllowMethod,
+    ExchangeAllowMethod _outgoExchangeAllowMethod,
+    address[] calldata _incomeTargetTokens,
+    address[] calldata _outgoTargetTokens
+) public override onlyOwner;
+```
+
+Required behavior:
+
+```solidity
+require(_afterDecreaseBp <= BP_BASE, "After decrease bp <= 10000");
+```
+
+`PCEToken.createToken` already performs equivalent validation before calling `setTokenSettings`; this proposal makes direct owner updates obey the same invariant.
+
+#### Version
+
+`PCECommunityToken.version()` MUST return `"1.0.17"` after this change.
+
+`PCEToken.version()` is unchanged by this proposal.
+
+#### Storage and state changes
+
+No storage variables are added, removed, reordered, or retyped.
+
+The proposal does not migrate balances, `lastModifiedFactor`, `lastDecreaseTime`, `rebaseFactor`, token settings, or any per-account storage. The only state changes during execution are the normal `updateFactorIfNeeded()` writes performed by the governance upgrade procedure below.
+
+#### Events and logs
+
+No new events are introduced. Existing functions keep their current event behavior.
+
+#### Governance upgrade procedure
+
+For existing deployments, the governance proposal MUST execute the factor update calls before the community-token implementation upgrade:
+
+1. Call `PCEToken.updateFactorIfNeeded()`.
+2. For every community token returned by `PCEToken.getTokens()` at proposal preparation time, call `PCECommunityToken(token).updateFactorIfNeeded()`.
+3. Upgrade the `PCECommunityToken` beacon implementation to the implementation containing this proposal.
+
+This order materializes all pending decay under the pre-upgrade formula before the new formula becomes active. From the first decay period after the upgrade, the WAD-precision formula applies.
+
+If governance also upgrades `PCEToken` in the same proposal for release packaging, that upgrade MUST NOT replace step 1 and MUST NOT be ordered before the update calls unless the new `PCEToken` implementation is behaviorally identical for `updateFactorIfNeeded()`.
+
+### Rationale
+
+#### Use WAD precision for the exponentiation base
+
+Community-token factors are stored and applied at WAD precision. Converting `afterDecreaseBp` to WAD before exponentiation keeps intermediate squared rates on the same scale as the stored factor and removes the repeated basis-point truncation. This is the smallest code change that makes `afterDecreaseBp = 9980` mean `0.998^n` for `n` periods.
+
+#### Keep O(log n) exponentiation
+
+The implementation keeps exponentiation-by-squaring instead of looping over every elapsed period. This preserves the gas and runtime characteristics of the existing implementation while correcting the precision of the intermediate values.
+
+#### Do not retroactively compensate users
+
+The proposal corrects the formula prospectively. It does not mint compensation, rewrite raw balances, or reinterpret past state. The contract has already exposed balances under the current formula, and a retroactive compensation mechanism would require a separate policy decision and additional state/accounting design.
+
+#### Materialize factors before upgrade
+
+Calling `updateFactorIfNeeded()` before the beacon upgrade creates a clean boundary: all pending decay up to the execution time uses the pre-upgrade formula, and all future decay uses the fixed formula. Without this step, an old unmaterialized decay window would be recalculated by the fixed formula after the upgrade, changing balances at the upgrade boundary without an explicit factor-update event from the pre-upgrade implementation.
+
+#### Add `setTokenSettings` validation
+
+`afterDecreaseBp > 10000` represents growth rather than decay and violates the existing invariant already enforced in `PCEToken.createToken`. Direct owner updates through `setTokenSettings` must obey the same invariant. This also keeps the corrected exponentiation bounded by `rate <= INITIAL_FACTOR`.
+
+### Backwards Compatibility
+
+The ABI is unchanged. Function names, parameters, return values, storage layout, and events remain compatible.
+
+Existing community tokens keep their stored settings and balances. After the governance procedure, their `lastModifiedFactor` and `lastDecreaseTime` are updated exactly as a normal pre-upgrade `updateFactorIfNeeded()` call would update them. Future decay then uses the corrected formula.
+
+The behavior change is visible in `getCurrentFactor()`, `balanceOf()`, `totalSupply()`, swap calculations, and transfer amounts expressed in display balance. The direction of the change is that future balances are no longer over-decayed by basis-point truncation.
+
+`setTokenSettings` becomes stricter for `_afterDecreaseBp > 10000`. This is not a breaking change for valid decay configurations because `PCEToken.createToken` already rejects the same invalid range.
+
+### Test Cases
+
+#### Two periods with 99.8% remaining rate
+
+Configuration:
+
+- `lastModifiedFactor = 1_000_000_000_000_000_000`
+- `decreaseIntervalDays = 7`
+- `afterDecreaseBp = 9980`
+- `times = 2`
+
+Expected fixed factor:
+
+```text
+0.998^2 * 1e18 = 996_004_000_000_000_000
+```
+
+Current basis-point squaring produces:
+
+```text
+996_000_000_000_000_000
+```
+
+#### Twelve periods with 99.8% remaining rate
+
+Configuration:
+
+- `lastModifiedFactor = 1_000_000_000_000_000_000`
+- `decreaseIntervalDays = 7`
+- `afterDecreaseBp = 9980`
+- `times = 12`
+
+Expected fixed factor:
+
+```text
+976_262_247_894_715_033
+```
+
+Current basis-point-precision factor:
+
+```text
+976_128_000_000_000_000
+```
+
+A holder with `1,000,000` display tokens at the starting factor would display:
+
+```text
+fixed:  976,262.247894715033 tokens
+current BP: 976,128.000000000000 tokens
+diff:   134.247894715033 tokens
+```
+
+#### Fifty-two periods with 99.8% remaining rate
+
+Configuration:
+
+- `lastModifiedFactor = 1_000_000_000_000_000_000`
+- `decreaseIntervalDays = 7`
+- `afterDecreaseBp = 9980`
+- `times = 52`
+
+Expected fixed factor:
+
+```text
+901_131_449_719_291_632
+```
+
+Current basis-point-precision factor:
+
+```text
+900_329_954_560_000_000
+```
+
+A holder with `1,000,000` display tokens at the starting factor would display:
+
+```text
+fixed:  901,131.449719291632 tokens
+current BP: 900,329.954560000000 tokens
+diff:   801.495159291632 tokens
+```
+
+#### No decay setting
+
+If `decreaseIntervalDays = 0`, `getCurrentFactor()` MUST return `lastModifiedFactor` without reading or exponentiating `afterDecreaseBp`.
+
+#### Full retention setting
+
+If `afterDecreaseBp = 10000`, `getCurrentFactor()` MUST return `lastModifiedFactor` for every elapsed period count.
+
+#### Invalid owner update
+
+`setTokenSettings(..., _afterDecreaseBp = 10001, ...)` MUST revert with:
+
+```text
+After decrease bp <= 10000
+```
+
+### Security Considerations
+
+Implementations MUST use `Math.mulDiv` for both `factor * rate / base` and `rate * rate / base`. With `_afterDecreaseBp <= BP_BASE`, the corrected `rate` is bounded by `INITIAL_FACTOR`, so repeated squaring cannot increase the rate above WAD. `Math.mulDiv` also preserves safe 512-bit intermediate multiplication semantics.
+
+Governance MUST execute `updateFactorIfNeeded()` for PCE and all known community tokens before the beacon upgrade. The token list SHOULD be generated from `PCEToken.getTokens()` close to proposal creation and reviewed before execution. If new community tokens can be created between proposal creation and execution, governance SHOULD either pause creation through operational policy for the proposal window or include any newly created tokens in a follow-up update before relying on a clean accounting boundary.
+
+The change makes future displayed balances higher than they would have been under the pre-upgrade over-decay formula. This is a correction toward the configured decay rate, not a mint, and it does not alter raw balances or reserve accounting.
+
+### Notes
+
+Out of scope:
+
+- Retroactive compensation for historical over-decay.
+- Raw balance migration.
+- Changes to PCE Token decay.
+- Changes to swap-rate, ARIGATO CREATION, voucher, or bridge formulas.
+- A new event for factor updates.
+
+### Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary

- Add PIP-21: Path-Consistent Community Token Decay Factor
- **PIP full text**: [PIPs/pip-21.md](https://github.com/peacecoin-protocol/PIPs/blob/feature/pip-21-decay-precision/PIPs/pip-21.md)
- Related core issue: [peacecoin-protocol/core#45](https://github.com/peacecoin-protocol/core/issues/45)
- Related core implementation PR: [peacecoin-protocol/core#46](https://github.com/peacecoin-protocol/core/pull/46)

## Abstract

This proposal fixes the current behavior in which community-token decay depends on how often `updateFactorIfNeeded()` is executed. It changes the multi-period decay calculation of `PCECommunityToken.getCurrentFactor()` so that the per-period community-token decay rate is exponentiated at WAD precision (`1e18`) instead of basis-point precision (`10000`), keeping batched multi-period calculation aligned with period-by-period materialization up to WAD rounding. It also adds the missing `afterDecreaseBp <= 10000` validation to `PCECommunityToken.setTokenSettings` and requires governance to materialize the current factor of every existing token before the implementation upgrade.

### Key Points

- **Fixes path-dependent current behavior**: the same settings and elapsed periods should not materially produce different results depending on transaction cadence or `updateFactorIfNeeded()` cadence.
- **Fixes basis-point intermediate truncation**: `afterDecreaseBp` is converted to WAD before exponentiation-by-squaring.
- **Preserves O(log n) calculation**: the gas/runtime structure of the current multi-period decay algorithm remains unchanged.
- **Keeps storage layout unchanged**: no storage variables are added, removed, reordered, or retyped.
- **Adds direct settings validation**: `setTokenSettings(..., _afterDecreaseBp > 10000, ...)` reverts with `After decrease bp <= 10000`.
- **Uses a clean upgrade boundary**: governance should call `updateFactorIfNeeded()` on PCE and all existing community tokens before upgrading the community-token beacon.
- **No retroactive compensation**: this is a prospective consistency/precision fix; raw balances and historical state are not migrated.

### Path-Dependence Example

```text
afterDecreaseBp = 9980
configured rate = 0.998

Period-by-period materialization:
1.000000 * 0.998 * 0.998 = 0.996004

Current batched calculation:
9980 * 9980 / 10000 = 9960
=> 0.996000
```

These should be equivalent. The current batched path is lower because it squares the rate after truncating it to basis-point precision.

For 12 weekly periods at 99.8% remaining rate:

```text
fixed factor:      976_262_247_894_715_033
current BP factor: 976_128_000_000_000_000
```

### Security Notes

The corrected rate is bounded by `INITIAL_FACTOR` when `_afterDecreaseBp <= BP_BASE`, and the implementation uses `Math.mulDiv` for the 512-bit intermediate multiplications. The governance upgrade procedure is part of the proposal because existing pending decay should be materialized with the pre-upgrade implementation before future decay switches to the fixed formula.

---

<details><summary>日本語版 PIP 全文</summary>

---
pip: 21
title: Path-Consistent Community Token Decay Factor
proposer: CHIBA Masahiro (@nihen)
status: Draft
type: Core
created: 2026-06-17
requires: []
replaces: []
---

## PIP-21: Path-Consistent Community Token Decay Factor

### Abstract（概要）

この提案は、Community Token の減衰結果が `updateFactorIfNeeded()` の実行頻度に依存する現行挙動を修正する。具体的には、`PCECommunityToken.getCurrentFactor()` の複数期間減衰計算において、期間ごとの減衰率を basis point 精度（`10000`）ではなく WAD 精度（`1e18`）で累乗し、複数期間をまとめて計算する場合と各期間ごとに materialize する場合の差を WAD rounding 範囲に抑える。あわせて、`PCECommunityToken.setTokenSettings` に不足していた `afterDecreaseBp <= 10000` の検証を追加し、既存トークンについては実装アップグレード前に governance が現在の factor を materialize することを必須とする。

### Motivation（動機）

Community Token の減衰は、本来であれば同じ設定と同じ経過期間に対して同じ結果を返すべきであり、transaction の発生頻度や `updateFactorIfNeeded()` の呼び出し頻度に依存すべきではない。現行実装はこの invariant を満たしていない。各減衰期間ごとに factor が materialize された場合と、複数期間経過後に 1 回の `getCurrentFactor()` でまとめて計算された場合で、結果が変わる。

Community Token の減衰は `afterDecreaseBp` で設定される。たとえば `9980` は、1 減衰期間ごとに残高が 99.8% 残ることを意味する。現行実装は最終結果を WAD に変換しているが、exponentiation-by-squaring の途中で rate を basis point 表現のまま二乗している。

```solidity
uint256 rate = afterDecreaseBp;
uint256 base = BP_BASE;
rate = Math.mulDiv(rate, rate, base);
```

`afterDecreaseBp = 9980` の場合、最初の二乗は `9980 * 9980 / 10000 = 9960` と整数切り捨てされる。一方、設定値として意図される 2 期間後の値は `0.998^2 = 0.996004` である。したがって現行実装では、各減衰期間ごとに factor を materialize する場合と、複数期間経過後に 1 回の `getCurrentFactor()` でまとめて計算する場合が等価ではない。後者は BP 精度で切り捨てられた二乗 rate を使うため、1 回の計算にまとめられる期間が長いほど、設定 rate に対する過剰減衰が累積する。

### Specification（仕様）

#### Scope

この提案が変更するのは Community Token の減衰 factor 計算と `setTokenSettings` の検証だけである。主目的は、複数期間減衰が transaction cadence / materialization cadence によって大きく変わる現行挙動を取り除くことであり、WAD 精度化はそのための実装手段である。PCE Token の減衰、swap 計算、ARIGATO CREATION、voucher logic、token balance、storage layout、event schema は変更しない。

#### Constants

既存の constants は現在の意味を維持する。

```solidity
uint256 public constant INITIAL_FACTOR = 10 ** 18;
uint256 public constant BP_BASE = 10_000;
```

`INITIAL_FACTOR` は display/raw balance conversion に使う WAD base である。`BP_BASE` は basis-point 設定値の input scale である。

#### PCECommunityToken.getCurrentFactor

実装は、exponentiation-by-squaring の前に `afterDecreaseBp` を WAD 精度へ変換しなければならない。

```solidity
function getCurrentFactor() public view returns (uint256);
```

複数期間計算部分は、次と等価でなければならない。

```solidity
uint256 times = elapsed / decreaseIntervalDays;
uint256 factor = lastModifiedFactor;
uint256 rate = Math.mulDiv(afterDecreaseBp, INITIAL_FACTOR, BP_BASE);
uint256 base = INITIAL_FACTOR;
uint256 n = times;

while (n > 0) {
    if (n % 2 == 1) {
        factor = Math.mulDiv(factor, rate, base);
    }
    rate = Math.mulDiv(rate, rate, base);
    n /= 2;
}

return factor;
```

既存の guard behavior は変更しない。

1. `lastModifiedFactor == 0` の場合は `0` を返す。
2. `decreaseIntervalDays == 0` の場合は `lastModifiedFactor` を返す。
3. `lastDecreaseTime` 以降に UTC day boundary を越えていない場合は `lastModifiedFactor` を返す。
4. 経過日数が `decreaseIntervalDays` 未満の場合は `lastModifiedFactor` を返す。

#### PCECommunityToken.setTokenSettings

次の既存関数は、100% を超える減衰設定を reject しなければならない。

```solidity
function setTokenSettings(
    uint256 _decreaseIntervalDays,
    uint16 _afterDecreaseBp,
    uint16 _maxIncreaseOfTotalSupplyBp,
    uint16 _maxIncreaseBp,
    uint16 _maxUsageBp,
    uint16 _changeBp,
    ExchangeAllowMethod _incomeExchangeAllowMethod,
    ExchangeAllowMethod _outgoExchangeAllowMethod,
    address[] calldata _incomeTargetTokens,
    address[] calldata _outgoTargetTokens
) public override onlyOwner;
```

Required behavior:

```solidity
require(_afterDecreaseBp <= BP_BASE, "After decrease bp <= 10000");
```

`PCEToken.createToken` はすでに `setTokenSettings` 呼び出し前に同等の検証を行っている。この提案は、owner による直接更新にも同じ invariant を適用する。

#### Version

この変更後、`PCECommunityToken.version()` は `"1.0.17"` を返さなければならない。

`PCEToken.version()` はこの提案では変更しない。

#### Storage and state changes

storage variable の追加・削除・並び替え・型変更は行わない。

この提案は balance、`lastModifiedFactor`、`lastDecreaseTime`、`rebaseFactor`、token settings、account storage を migrate しない。execution 時の state change は、下記 governance upgrade procedure によって実行される通常の `updateFactorIfNeeded()` の write だけである。

#### Events and logs

新しい event は追加しない。既存関数の event behavior も変更しない。

#### Governance upgrade procedure

既存 deployment では、governance proposal は Community Token 実装アップグレードより前に factor update call を実行しなければならない。

1. `PCEToken.updateFactorIfNeeded()` を呼ぶ。
2. proposal 準備時点の `PCEToken.getTokens()` が返すすべての Community Token に対して、`PCECommunityToken(token).updateFactorIfNeeded()` を呼ぶ。
3. `PCECommunityToken` beacon implementation を、この提案を含む implementation に upgrade する。

この順序により、execution 時点までの pending decay はアップグレード前の式で materialize される。upgrade 後の最初の減衰期間から WAD-precision formula が適用される。

release packaging の都合で同じ proposal 内で `PCEToken` も upgrade する場合、その upgrade は step 1 を置き換えてはならない。また、新しい `PCEToken` implementation の `updateFactorIfNeeded()` が behaviorally identical でない限り、update call より前に配置してはならない。

### Rationale（設計根拠）

#### exponentiation base に WAD 精度を使う

Community Token の factor は WAD 精度で保存され、display/raw balance conversion に使われる。`afterDecreaseBp` を exponentiation の前に WAD に変換することで、中間の二乗 rate が保存 factor と同じ scale になり、basis point 精度での繰り返し切り捨てがなくなる。これは、`afterDecreaseBp = 9980` を `n` 期間後に `0.998^n` と解釈するための最小変更である。

#### O(log n) の exponentiation を維持する

実装は期間数に比例して loop するのではなく、既存の exponentiation-by-squaring を維持する。これにより、既存実装の gas/runtime characteristics を保ったまま、中間値の精度だけを修正する。

#### retroactive compensation は行わない

この提案は formula を将来に向けて修正する。compensation の mint、raw balance の書き換え、過去 state の再解釈は行わない。コントラクトはすでに現行式に基づく balance を公開しており、retroactive compensation には別の policy decision と追加の state/accounting design が必要である。

#### upgrade 前に factor を materialize する

beacon upgrade 前に `updateFactorIfNeeded()` を呼ぶことで、execution 時点までの decay はアップグレード前の式、以後の decay は fixed という明確な境界を作る。この step がない場合、古い未 materialize 減衰期間が upgrade 後に fixed formula で再計算され、アップグレード前 implementation 由来の明示的な factor-update event なしに upgrade 境界で balance が変わる。

#### `setTokenSettings` validation を追加する

`afterDecreaseBp > 10000` は decay ではなく growth を意味し、`PCEToken.createToken` がすでに enforcement している invariant に反する。`setTokenSettings` による owner direct update でも同じ invariant を守る必要がある。この制約により、修正後の exponentiation は `rate <= INITIAL_FACTOR` に bounded される。

### Backwards Compatibility（後方互換性）

ABI は変更しない。function name、parameter、return value、storage layout、event は互換である。

既存 Community Token は保存済み settings と balances を維持する。governance procedure 後、それぞれの `lastModifiedFactor` と `lastDecreaseTime` は通常のアップグレード前 `updateFactorIfNeeded()` call と同じ形で更新される。その後の future decay は corrected formula を使う。

動作変更は `getCurrentFactor()`、`balanceOf()`、`totalSupply()`、swap calculation、display balance で表される transfer amount に現れる。変更の方向は、future balance がアップグレード前の過剰減衰式によって過剰に減らなくなることである。

`setTokenSettings` は `_afterDecreaseBp > 10000` に対して stricter になる。有効な decay configuration に対する breaking change ではない。`PCEToken.createToken` はすでに同じ invalid range を reject している。

### Test Cases（テストケース）

#### 99.8% remaining rate の 2 期間

Configuration:

- `lastModifiedFactor = 1_000_000_000_000_000_000`
- `decreaseIntervalDays = 7`
- `afterDecreaseBp = 9980`
- `times = 2`

Expected fixed factor:

```text
0.998^2 * 1e18 = 996_004_000_000_000_000
```

Current basis-point squaring produces:

```text
996_000_000_000_000_000
```

#### 99.8% remaining rate の 12 期間

Configuration:

- `lastModifiedFactor = 1_000_000_000_000_000_000`
- `decreaseIntervalDays = 7`
- `afterDecreaseBp = 9980`
- `times = 12`

Expected fixed factor:

```text
976_262_247_894_715_033
```

Current basis-point-precision factor:

```text
976_128_000_000_000_000
```

開始 factor 時点で `1,000,000` display tokens を持つ holder の表示値は次の通りである。

```text
fixed:  976,262.247894715033 tokens
current BP: 976,128.000000000000 tokens
diff:   134.247894715033 tokens
```

#### 99.8% remaining rate の 52 期間

Configuration:

- `lastModifiedFactor = 1_000_000_000_000_000_000`
- `decreaseIntervalDays = 7`
- `afterDecreaseBp = 9980`
- `times = 52`

Expected fixed factor:

```text
901_131_449_719_291_632
```

Current basis-point-precision factor:

```text
900_329_954_560_000_000
```

開始 factor 時点で `1,000,000` display tokens を持つ holder の表示値は次の通りである。

```text
fixed:  901,131.449719291632 tokens
current BP: 900,329.954560000000 tokens
diff:   801.495159291632 tokens
```

#### No decay setting

`decreaseIntervalDays = 0` の場合、`getCurrentFactor()` は `afterDecreaseBp` を読んだり累乗したりせずに `lastModifiedFactor` を返さなければならない。

#### Full retention setting

`afterDecreaseBp = 10000` の場合、`getCurrentFactor()` はどの elapsed period count に対しても `lastModifiedFactor` を返さなければならない。

#### Invalid owner update

`setTokenSettings(..., _afterDecreaseBp = 10001, ...)` は次の message で revert しなければならない。

```text
After decrease bp <= 10000
```

### Security Considerations（セキュリティ考慮事項）

実装は `factor * rate / base` と `rate * rate / base` の両方に `Math.mulDiv` を使わなければならない。`_afterDecreaseBp <= BP_BASE` により、修正後の `rate` は `INITIAL_FACTOR` 以下に bounded されるため、繰り返し二乗によって WAD を超えて増加しない。`Math.mulDiv` は 512-bit intermediate multiplication semantics も維持する。

governance は beacon upgrade 前に PCE とすべての既知 Community Token に対して `updateFactorIfNeeded()` を実行しなければならない。token list は proposal creation に近い時点で `PCEToken.getTokens()` から生成し、execution 前に review すべきである。proposal creation と execution の間に新しい Community Token が作成される場合、governance は proposal window 中の token creation を運用上停止するか、clean accounting boundary を前提にする前に新規 token に対する follow-up update を含めるべきである。

この変更により、future displayed balance はアップグレード前の過剰減衰式より高くなる。これは設定された decay rate に近づける修正であり、mint ではない。raw balance や reserve accounting は変更しない。

### Notes（補足）

Out of scope:

- historical over-decay への retroactive compensation。
- raw balance migration。
- PCE Token decay の変更。
- swap-rate、ARIGATO CREATION、voucher、bridge formula の変更。
- factor update 用の新 event。

### Copyright（著作権）

Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

</details>
